### PR TITLE
resolves android api25 TypeError

### DIFF
--- a/app/javascript/mastodon/components/poll.js
+++ b/app/javascript/mastodon/components/poll.js
@@ -37,6 +37,10 @@ class Poll extends ImmutablePureComponent {
     expired: null,
   };
 
+  static defaultProps = {
+    disabled: true,
+  };
+
   static getDerivedStateFromProps (props, state) {
     const { poll, intl } = props;
     const expired = poll.get('expired') || (new Date(poll.get('expires_at'))).getTime() < intl.now();

--- a/app/javascript/mastodon/features/ui/index.js
+++ b/app/javascript/mastodon/features/ui/index.js
@@ -165,7 +165,9 @@ class SwitchingColumnsArea extends React.PureComponent {
   }
 
   setRef = c => {
-    this.node = c.getWrappedInstance();
+    if (c) {
+      this.node = c.getWrappedInstance();
+    }
   }
 
   render () {
@@ -387,7 +389,9 @@ class UI extends React.PureComponent {
   }
 
   setRef = c => {
-    this.node = c;
+    if (c) {
+      this.node = c;
+    }
   }
 
   handleHotkeyNew = e => {


### PR DESCRIPTION
`git checkout api25-hotfix && git pull` 

This PR resolves the primary error in mastodon on Android API 25 and resolves the secondary error that was a result of the primary error fix.

**REQUIRED:** Android Emulator or Android Phone on APIs 24, 25, and >25.

__Note:__ If testing using mastodon hosted on `localhost:3000`, on your test device you will have to use `10.0.2.2:3000` if connected to computer or your computers IP ex: `192.168.0.11`

AC:
In the bridges app or in chrome browser on Android Device/Emulator using API 24, 25, >25 log in to your homepage and navigate through the pages.
- [ ]   API 24 works as expected.
- [ ]   API 25 works as expected.
- [ ]   API >25 works as expected.


Primary Error:
```
TypeError: Cannot read property 'getWrappedInstance' of null
    at https://heal3.poly.asu.edu/packs/js/application-5cdc9c7a3ed9f451c6c0.chunk.js:1:30202
    at pi (https://heal3.poly.asu.edu/packs/js/common-19e692fb0eb482cbc70f.js:34:75173)
    at mi (https://heal3.poly.asu.edu/packs/js/common-19e692fb0eb482cbc70f.js:34:75715)
    at vi (https://heal3.poly.asu.edu/packs/js/common-19e692fb0eb482cbc70f.js:34:77391)
    at zi (https://heal3.poly.asu.edu/packs/js/common-19e692fb0eb482cbc70f.js:34:81515)
    at Ki (https://heal3.poly.asu.edu/packs/js/common-19e692fb0eb482cbc70f.js:34:85080)
    at https://heal3.poly.asu.edu/packs/js/common-19e692fb0eb482cbc70f.js:34:98357
    at Object.t.unstable_runWithPriority (https://heal3.poly.asu.edu/packs/js/common-19e692fb0eb482cbc70f.js:43:3200)
    at Ns (https://heal3.poly.asu.edu/packs/js/common-19e692fb0eb482cbc70f.js:34:98291)
    at Fs (https://heal3.poly.asu.edu/packs/js/common-19e692fb0eb482cbc70f.js:34:98067)
```


Secondary Error:
```
 TypeError: Object.entries is not a function
    at Poll.render (webpack-internal:///./app/javascript/mastodon/components/poll.js:309:50)
    at finishClassComponent (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:15320:35)
    at updateClassComponent (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:15275:28)
    at beginWork (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:16265:20)
    at performUnitOfWork (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:20285:16)
    at workLoop (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:20326:28)
    at renderRoot (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:20406:11)
    at performWorkOnRoot (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:21363:11)
    at performWork (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:21273:11)
    at performSyncWork (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:21247:7)
    at batchedUpdates$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:21474:11)
```