### PR TITLE
goals

### DIFF
--- a/app/controllers/api/v1/statuses_controller.rb
+++ b/app/controllers/api/v1/statuses_controller.rb
@@ -38,6 +38,7 @@ class Api::V1::StatusesController < Api::BaseController
                                          text: status_params[:status],
                                          thread: status_params[:in_reply_to_id].blank? ? nil : Status.find(status_params[:in_reply_to_id]),
                                          futureself: status_params[:futureSelf] || false, # this passes the endpoint property to the service
+                                         goal: status_params[:goal] || false, # this passes the endpoint property to the service
                                          media_ids: status_params[:media_ids],
                                          sensitive: status_params[:sensitive],
                                          spoiler_text: status_params[:spoiler_text],
@@ -78,6 +79,7 @@ class Api::V1::StatusesController < Api::BaseController
       :visibility,
       :scheduled_at,
       :futureSelf, # this adds futureself as a param in the payload
+      :goal, # this adds goal as a param in the payload
       media_ids: [],
       poll: [
         :multiple,

--- a/app/javascript/mastodon/actions/compose.js
+++ b/app/javascript/mastodon/actions/compose.js
@@ -43,6 +43,7 @@ export const COMPOSE_SPOILERNESS_CHANGE = 'COMPOSE_SPOILERNESS_CHANGE';
 export const COMPOSE_SPOILER_TEXT_CHANGE = 'COMPOSE_SPOILER_TEXT_CHANGE';
 export const COMPOSE_VISIBILITY_CHANGE  = 'COMPOSE_VISIBILITY_CHANGE';
 export const COMPOSE_FUTURE_SELF_CHANGE  = 'COMPOSE_FUTURE_SELF_CHANGE';
+export const COMPOSE_GOAL_CHANGE  = 'COMPOSE_GOAL_CHANGE';
 export const COMPOSE_LISTABILITY_CHANGE = 'COMPOSE_LISTABILITY_CHANGE';
 export const COMPOSE_COMPOSING_CHANGE = 'COMPOSE_COMPOSING_CHANGE';
 
@@ -144,7 +145,7 @@ export function submitCompose(routerHistory) {
       visibility: getState().getIn(['compose', 'privacy']),
       poll: getState().getIn(['compose', 'poll'], null),
       futureSelf: getState().getIn(['compose', 'futureSelf']),
-      goal: status.includes('#goal'), // TODO UPDATE TO USE getState like poll does
+      goal: getState().getIn(['compose', 'goal']),
     }, {
       headers: {
         'Idempotency-Key': getState().getIn(['compose', 'idempotencyKey']),
@@ -531,6 +532,13 @@ export function changeComposeVisibility(value) {
 export function changeComposeFutureSelf(value) {
   return {
     type: COMPOSE_FUTURE_SELF_CHANGE,
+    value,
+  };
+};
+
+export function changeComposeGoal(value) {
+  return {
+    type: COMPOSE_GOAL_CHANGE,
     value,
   };
 };

--- a/app/javascript/mastodon/actions/compose.js
+++ b/app/javascript/mastodon/actions/compose.js
@@ -539,7 +539,7 @@ export function changeComposeFutureSelf(value) {
 
 export function goalCompose(status, routerHistory) {
   return (dispatch, getState) => {
-    dispatch(addPoll()); // TODO modify this to show the Goal Form not a poll.
+    // dispatch(addPoll()); // TODO modify this to show the Goal Form not a poll.
     dispatch({
       type: COMPOSE_GOAL,
       status: status,

--- a/app/javascript/mastodon/actions/compose.js
+++ b/app/javascript/mastodon/actions/compose.js
@@ -43,7 +43,7 @@ export const COMPOSE_SPOILERNESS_CHANGE = 'COMPOSE_SPOILERNESS_CHANGE';
 export const COMPOSE_SPOILER_TEXT_CHANGE = 'COMPOSE_SPOILER_TEXT_CHANGE';
 export const COMPOSE_VISIBILITY_CHANGE  = 'COMPOSE_VISIBILITY_CHANGE';
 export const COMPOSE_FUTURE_SELF_CHANGE  = 'COMPOSE_FUTURE_SELF_CHANGE';
-export const COMPOSE_GOAL_CHANGE  = 'COMPOSE_GOAL_CHANGE';
+export const COMPOSE_GOAL  = 'COMPOSE_GOAL';
 export const COMPOSE_LISTABILITY_CHANGE = 'COMPOSE_LISTABILITY_CHANGE';
 export const COMPOSE_COMPOSING_CHANGE = 'COMPOSE_COMPOSING_CHANGE';
 
@@ -90,6 +90,7 @@ export function replyCompose(status, routerHistory) {
     ensureComposeIsVisible(getState, routerHistory);
   };
 };
+
 
 export function cancelReplyCompose() {
   return {
@@ -536,10 +537,14 @@ export function changeComposeFutureSelf(value) {
   };
 };
 
-export function changeComposeGoal(value) {
-  return {
-    type: COMPOSE_GOAL_CHANGE,
-    value,
+export function goalCompose(status, routerHistory) {
+  return (dispatch, getState) => {
+    dispatch({
+      type: COMPOSE_GOAL,
+      status: status,
+    });
+
+    ensureComposeIsVisible(getState, routerHistory);
   };
 };
 

--- a/app/javascript/mastodon/actions/compose.js
+++ b/app/javascript/mastodon/actions/compose.js
@@ -539,6 +539,7 @@ export function changeComposeFutureSelf(value) {
 
 export function goalCompose(status, routerHistory) {
   return (dispatch, getState) => {
+    dispatch(addPoll()); // TODO modify this to show the Goal Form not a poll.
     dispatch({
       type: COMPOSE_GOAL,
       status: status,

--- a/app/javascript/mastodon/actions/statuses.js
+++ b/app/javascript/mastodon/actions/statuses.js
@@ -148,6 +148,8 @@ export function deleteStatus(id, routerHistory, withRedraft = false) {
       status = status.set('poll', getState().getIn(['polls', status.get('poll')]));
     }
 
+    // TODO check if goal and re-build status
+
     dispatch(deleteStatusRequest(id));
 
     api(getState).delete(`/api/v1/statuses/${id}`).then(response => {

--- a/app/javascript/mastodon/components/autosuggest_input.js
+++ b/app/javascript/mastodon/components/autosuggest_input.js
@@ -194,7 +194,6 @@ export default class AutosuggestInput extends ImmutablePureComponent {
     if (isRtl(value)) {
       style.direction = 'rtl';
     }
-
     return (
       <div className='autosuggest-input'>
         <label>
@@ -220,9 +219,9 @@ export default class AutosuggestInput extends ImmutablePureComponent {
           />
         </label>
 
-        <div className={`autosuggest-textarea__suggestions ${suggestionsHidden || suggestions.isEmpty() ? '' : 'autosuggest-textarea__suggestions--visible'}`}>
+        {suggestions !== null && <div className={`autosuggest-textarea__suggestions ${suggestionsHidden || suggestions.isEmpty() ? '' : 'autosuggest-textarea__suggestions--visible'}`}>
           {suggestions.map(this.renderSuggestion)}
-        </div>
+        </div>}
       </div>
     );
   }

--- a/app/javascript/mastodon/components/autosuggest_textarea.js
+++ b/app/javascript/mastodon/components/autosuggest_textarea.js
@@ -201,39 +201,71 @@ export default class AutosuggestTextarea extends ImmutablePureComponent {
       style.direction = 'rtl';
     }
 
-    return [
-      <div className='compose-form__autosuggest-wrapper' key='autosuggest-wrapper'>
-        <div className='autosuggest-textarea'>
-          <label>
-            <span style={{ display: 'none' }}>{placeholder}</span>
+    if(this.props.goal) {
+      return (
+        <div className='compose-form__autosuggest-wrapper' key='autosuggest-wrapper'>
+          <div className='autosuggest-textarea'>
+            <label>
+              <span style={{ display: 'none' }}>{placeholder}</span>
 
-            <Textarea
-              inputRef={this.setTextarea}
-              className='autosuggest-textarea__textarea'
-              disabled={disabled}
-              placeholder={placeholder}
-              autoFocus={autoFocus}
-              value={value}
-              onChange={this.onChange}
-              onKeyDown={this.onKeyDown}
-              onKeyUp={onKeyUp}
-              onFocus={this.onFocus}
-              onBlur={this.onBlur}
-              onPaste={this.onPaste}
-              style={style}
-              aria-autocomplete='list'
-            />
-          </label>
+              <Textarea
+                inputRef={this.setTextarea}
+                className='goal-textarea__textarea'
+                disabled={disabled}
+                placeholder={placeholder}
+                autoFocus={autoFocus}
+                value={value}
+                onChange={this.onChange}
+                onKeyDown={this.onKeyDown}
+                onKeyUp={onKeyUp}
+                onFocus={this.onFocus}
+                onBlur={this.onBlur}
+                onPaste={this.onPaste}
+                style={{ direction: 'ltr', height:10 }}
+                aria-autocomplete='list'
+              />
+            </label>
+          </div>
+          {children}
         </div>
-        {children}
-      </div>,
+      );
+    } else {
+      return [
+        <div className='compose-form__autosuggest-wrapper' key='autosuggest-wrapper'>
+          <div className='autosuggest-textarea'>
+            <label>
+              <span style={{ display: 'none' }}>{placeholder}</span>
 
-      <div className='autosuggest-textarea__suggestions-wrapper' key='suggestions-wrapper'>
-        <div className={`autosuggest-textarea__suggestions ${suggestionsHidden || suggestions.isEmpty() ? '' : 'autosuggest-textarea__suggestions--visible'}`}>
-          {suggestions.map(this.renderSuggestion)}
-        </div>
-      </div>,
-    ];
+              <Textarea
+                inputRef={this.setTextarea}
+                className={'autosuggest-textarea__textarea'}
+                disabled={disabled}
+                placeholder={placeholder}
+                autoFocus={autoFocus}
+                value={value}
+                onChange={this.onChange}
+                onKeyDown={this.onKeyDown}
+                onKeyUp={onKeyUp}
+                onFocus={this.onFocus}
+                onBlur={this.onBlur}
+                onPaste={this.onPaste}
+                style={style}
+                aria-autocomplete='list'
+              />
+            </label>
+          </div>
+          {children}
+        </div>,
+
+        <div className='autosuggest-textarea__suggestions-wrapper' key='suggestions-wrapper'>
+          <div
+            className={`autosuggest-textarea__suggestions ${suggestionsHidden || suggestions.isEmpty() ? '' : 'autosuggest-textarea__suggestions--visible'}`}
+          >
+            {suggestions.map(this.renderSuggestion)}
+          </div>
+        </div>,
+      ];
+    }
   }
 
 }

--- a/app/javascript/mastodon/components/poll.js
+++ b/app/javascript/mastodon/components/poll.js
@@ -38,7 +38,7 @@ class Poll extends ImmutablePureComponent {
   };
 
   static defaultProps = {
-    disabled: true,
+    disabled: false,
   };
 
   static getDerivedStateFromProps (props, state) {
@@ -57,6 +57,15 @@ class Poll extends ImmutablePureComponent {
 
   componentWillUnmount () {
     clearTimeout(this._timer);
+  }
+
+  checkEntries() {
+    try {
+      return Object.entries(this.state.selected).every(item => !item);
+    } catch (e) {
+      console.log(e + ' no selected entries, returning false');
+      return false;
+    }
   }
 
   _setupTimer () {
@@ -160,7 +169,7 @@ class Poll extends ImmutablePureComponent {
 
     const timeRemaining = expired ? intl.formatMessage(messages.closed) : <RelativeTimestamp timestamp={poll.get('expires_at')} futureDate />;
     const showResults   = poll.get('voted') || expired;
-    const disabled      = this.props.disabled || Object.entries(this.state.selected).every(item => !item);
+    const disabled      = this.props.disabled || this.checkEntries();
 
     let votesCount = null;
 

--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -64,6 +64,7 @@ class Status extends ImmutablePureComponent {
     otherAccounts: ImmutablePropTypes.list,
     onClick: PropTypes.func,
     onReply: PropTypes.func,
+    onGoal: PropTypes.func,
     onFavourite: PropTypes.func,
     onReblog: PropTypes.func,
     onDelete: PropTypes.func,
@@ -219,6 +220,11 @@ class Status extends ImmutablePureComponent {
     this.props.onReply(this._properStatus(), this.context.router.history);
   }
 
+  handleHotkeyGoal = e => {
+    e.preventDefault();
+    this.props.onGoal(this._properStatus(), this.context.router.history);
+  }
+
   handleHotkeyFavourite = () => {
     this.props.onFavourite(this._properStatus());
   }
@@ -284,6 +290,7 @@ class Status extends ImmutablePureComponent {
 
     const handlers = this.props.muted ? {} : {
       reply: this.handleHotkeyReply,
+      goal: this.handleHotkeyGoal,
       favourite: this.handleHotkeyFavourite,
       boost: this.handleHotkeyBoost,
       mention: this.handleHotkeyMention,

--- a/app/javascript/mastodon/components/status_action_bar.js
+++ b/app/javascript/mastodon/components/status_action_bar.js
@@ -56,6 +56,7 @@ class StatusActionBar extends ImmutablePureComponent {
     account: ImmutablePropTypes.map,
     status: ImmutablePropTypes.map.isRequired,
     onReply: PropTypes.func,
+    onGoal: PropTypes.func,
     onFavourite: PropTypes.func,
     onReblog: PropTypes.func,
     onDelete: PropTypes.func,
@@ -87,10 +88,11 @@ class StatusActionBar extends ImmutablePureComponent {
   }
 
   handleGoalClick = () => {
+    // alert(me);
     if (me) {
-      this.props.onReply(this.props.status, this.context.router.history);
+      this.props.onGoal(this.props.status, this.context.router.history);
     } else {
-      throw new Error('unable to create a goal for a post that is not recognized as your own.');
+      alert(me);
     }
   }
 
@@ -263,7 +265,7 @@ class StatusActionBar extends ImmutablePureComponent {
         <div className='status__action-bar__counter'><IconButton className='status__action-bar-button' title={replyTitle} icon={status.get('in_reply_to_account_id') === status.getIn(['account', 'id']) ? 'reply' : replyIcon} onClick={this.handleReplyClick} /><span className='status__action-bar__counter__label' >{obfuscatedCount(status.get('replies_count'))}</span></div>
         <IconButton className='status__action-bar-button' disabled={!publicStatus} active={status.get('reblogged')} pressed={status.get('reblogged')} title={!publicStatus ? intl.formatMessage(messages.cannot_reblog) : intl.formatMessage(messages.reblog)} icon={reblogIcon} onClick={this.handleReblogClick} />
         <IconButton className='status__action-bar-button star-icon' animate active={status.get('favourited')} pressed={status.get('favourited')} title={intl.formatMessage(messages.favourite)} icon='star' onClick={this.handleFavouriteClick} />
-        {status.get('futureself') && <IconButton className='status__action-bar-button' title={goalTitle} icon={goalIcon} onClick={this.handleGoalClick} />}
+        {status.get('futureself') && status.getIn(['account', 'id']) === `${me}` && <IconButton className='status__action-bar-button' title={goalTitle} icon={goalIcon} onClick={this.handleGoalClick} />}
         {shareButton}
 
         <div className='status__action-bar-dropdown'>

--- a/app/javascript/mastodon/components/status_action_bar.js
+++ b/app/javascript/mastodon/components/status_action_bar.js
@@ -86,6 +86,14 @@ class StatusActionBar extends ImmutablePureComponent {
     }
   }
 
+  handleGoalClick = () => {
+    if (me) {
+      this.props.onReply(this.props.status, this.context.router.history);
+    } else {
+      throw new Error('unable to create a goal for a post that is not recognized as your own.');
+    }
+  }
+
   handleShareClick = () => {
     navigator.share({
       text: this.props.status.get('search_index'),
@@ -179,7 +187,7 @@ class StatusActionBar extends ImmutablePureComponent {
   }
 
   render () {
-    const { account, status, intl, withDismiss } = this.props;
+    const { status, intl, withDismiss } = this.props;
 
     const mutingConversation = status.get('muted');
     const anonymousAccess    = !me;
@@ -187,6 +195,8 @@ class StatusActionBar extends ImmutablePureComponent {
 
     let menu = [];
     let reblogIcon = 'retweet';
+    let goalIcon = 'flag';
+    let goalTitle = 'create goal';
     let replyIcon;
     let replyTitle;
 
@@ -248,12 +258,12 @@ class StatusActionBar extends ImmutablePureComponent {
     const shareButton = ('share' in navigator) && status.get('visibility') === 'public' && (
       <IconButton className='status__action-bar-button' title={intl.formatMessage(messages.share)} icon='share-alt' onClick={this.handleShareClick} />
     );
-
     return (
       <div className='status__action-bar'>
         <div className='status__action-bar__counter'><IconButton className='status__action-bar-button' title={replyTitle} icon={status.get('in_reply_to_account_id') === status.getIn(['account', 'id']) ? 'reply' : replyIcon} onClick={this.handleReplyClick} /><span className='status__action-bar__counter__label' >{obfuscatedCount(status.get('replies_count'))}</span></div>
         <IconButton className='status__action-bar-button' disabled={!publicStatus} active={status.get('reblogged')} pressed={status.get('reblogged')} title={!publicStatus ? intl.formatMessage(messages.cannot_reblog) : intl.formatMessage(messages.reblog)} icon={reblogIcon} onClick={this.handleReblogClick} />
         <IconButton className='status__action-bar-button star-icon' animate active={status.get('favourited')} pressed={status.get('favourited')} title={intl.formatMessage(messages.favourite)} icon='star' onClick={this.handleFavouriteClick} />
+        {status.get('futureself') && <IconButton className='status__action-bar-button' title={goalTitle} icon={goalIcon} onClick={this.handleGoalClick} />}
         {shareButton}
 
         <div className='status__action-bar-dropdown'>

--- a/app/javascript/mastodon/components/status_content.js
+++ b/app/javascript/mastodon/components/status_content.js
@@ -108,6 +108,8 @@ export default class StatusContent extends React.PureComponent {
   componentDidUpdate () {
     this._updateStatusLinks();
     this._updateStatusEmojis();
+    if(this.props.status.get('goal'))
+      this.parseGoal(this.props.status.get('content'));
   }
 
   /**

--- a/app/javascript/mastodon/components/status_content.js
+++ b/app/javascript/mastodon/components/status_content.js
@@ -8,6 +8,7 @@ import classnames from 'classnames';
 import PollContainer from 'mastodon/containers/poll_container';
 import Icon from 'mastodon/components/icon';
 import { autoPlayGif } from 'mastodon/initial_state';
+import GoalForm from '../features/compose/components/goal_form';
 
 const MAX_HEIGHT = 642; // 20px * 32 (+ 2px padding at the top)
 
@@ -28,6 +29,9 @@ export default class StatusContent extends React.PureComponent {
   state = {
     hidden: true,
     collapsed: null, //  `collapsed: null` indicates that an element doesn't need collapsing, while `true` or `false` indicates that it does (and is/isn't).
+    goal: '',
+    goalImportance: '',
+    goalPlan: '',
   };
 
   _updateStatusLinks () {
@@ -97,12 +101,39 @@ export default class StatusContent extends React.PureComponent {
   componentDidMount () {
     this._updateStatusLinks();
     this._updateStatusEmojis();
+    if(this.props.status.get('goal'))
+      this.parseGoal(this.props.status.get('content'));
   }
 
   componentDidUpdate () {
     this._updateStatusLinks();
     this._updateStatusEmojis();
   }
+
+  /**
+   * 'My Goal is:\n'
+   + this.autosuggestTextarea.textarea.value
+   + '\n\nThe goal is important to me because:'
+   + '\n'+this.state.goalImportance
+   + '\n\nTo achieve this goal I will:'
+   + '\n'+this.state.goalPlan);
+   * @param text
+   */
+  parseGoal = (text) => {
+    try {
+      text = text.slice(3,-4); //remove the <p></p>
+      let goalStrings = text.split(',');
+      // alert(goalStrings);
+      this.setState({ goal: goalStrings[0] });
+      this.setState({ goalImportance: goalStrings[1] });
+      this.setState({ goalPlan: goalStrings[2] });
+    } catch (e) {
+      this.setState({ goal: 'oops there' });
+      this.setState({ goalImportance: 'was an error' });
+      this.setState({ goalPlan: e });
+    }
+    // alert(this.state.goal)
+}
 
   onMentionClick = (mention, e) => {
     if (this.context.router && e.button === 0 && !(e.ctrlKey || e.metaKey)) {
@@ -223,17 +254,19 @@ export default class StatusContent extends React.PureComponent {
 
           {mentionsPlaceholder}
 
-          <div tabIndex={!hidden ? 0 : null} className={`status__content__text ${!hidden ? 'status__content__text--visible' : ''}`} style={directionStyle} dangerouslySetInnerHTML={content} />
+          {!status.get('goal') && <div tabIndex={!hidden ? 0 : null} className={`status__content__text ${!hidden ? 'status__content__text--visible' : ''}`} style={directionStyle} dangerouslySetInnerHTML={content} />}
 
           {!hidden && !!status.get('poll') && <PollContainer pollId={status.get('poll')} />}
+          {status.get('goal') && <GoalForm display goal={this.state.goal} goalImportance={this.state.goalImportance} goalPlan={this.state.goalPlan}  />}
         </div>
       );
     } else if (this.props.onClick) {
       const output = [
         <div className={classNames} ref={this.setRef} tabIndex='0' style={directionStyle} onMouseDown={this.handleMouseDown} onMouseUp={this.handleMouseUp} key='status-content'>
-          <div className='status__content__text status__content__text--visible' style={directionStyle} dangerouslySetInnerHTML={content} />
+          {!status.get('goal') && <div className='status__content__text status__content__text--visible' style={directionStyle} dangerouslySetInnerHTML={content} />}
 
           {!!status.get('poll') && <PollContainer pollId={status.get('poll')} />}
+          {status.get('goal') && <GoalForm display goal={this.state.goal} goalImportance={this.state.goalImportance} goalPlan={this.state.goalPlan}  />}
         </div>,
       ];
 
@@ -245,9 +278,10 @@ export default class StatusContent extends React.PureComponent {
     } else {
       return (
         <div className={classNames} ref={this.setRef} tabIndex='0' style={directionStyle}>
-          <div className='status__content__text status__content__text--visible' style={directionStyle} dangerouslySetInnerHTML={content} />
+          {!status.get('goal') && <div className='status__content__text status__content__text--visible' style={directionStyle} dangerouslySetInnerHTML={content} />}
 
           {!!status.get('poll') && <PollContainer pollId={status.get('poll')} />}
+          {status.get('goal') && <GoalForm display goal={this.state.goal} goalImportance={this.state.goalImportance} goalPlan={this.state.goalPlan}  />}
         </div>
       );
     }

--- a/app/javascript/mastodon/containers/status_container.js
+++ b/app/javascript/mastodon/containers/status_container.js
@@ -5,6 +5,7 @@ import {
   replyCompose,
   mentionCompose,
   directCompose,
+  goalCompose,
 } from '../actions/compose';
 import {
   reblog,
@@ -62,6 +63,22 @@ const mapDispatchToProps = (dispatch, { intl }) => ({
         }));
       } else {
         dispatch(replyCompose(status, router));
+      }
+    });
+  },
+
+  onGoal (status, router) {
+    dispatch((_, getState) => {
+      let state = getState();
+
+      if (state.getIn(['compose', 'text']).trim().length !== 0) {
+        dispatch(openModal('CONFIRM', {
+          message: intl.formatMessage(messages.replyMessage),
+          confirm: intl.formatMessage(messages.replyConfirm),
+          onConfirm: () => dispatch(goalCompose(status, router)),
+        }));
+      } else {
+        dispatch(goalCompose(status, router));
       }
     });
   },

--- a/app/javascript/mastodon/features/compose/components/compose_form.js
+++ b/app/javascript/mastodon/features/compose/components/compose_form.js
@@ -57,6 +57,7 @@ class ComposeForm extends ImmutablePureComponent {
     hasTag: false,
     hasImage: false,
     hasText: false,
+    goal: '',
     goalImportance: '',
     goalPlan: '',
   };
@@ -146,6 +147,10 @@ class ComposeForm extends ImmutablePureComponent {
     }
   }
 
+  handleGoalChange = e => {
+    this.setState({ goal: e.target.value });
+  };
+
   handleGoalImportanceChange = e => {
     this.setState({ goalImportance: e.target.value });
   };
@@ -183,12 +188,13 @@ class ComposeForm extends ImmutablePureComponent {
 
     if (goal) {
       this.props.onChange(
-        'My Goal:\n'
-        + this.autosuggestTextarea.textarea.value
-        + '\n\nThe goal is important to me because:'
-        + '\n'+this.state.goalImportance
-        + '\n\nTo achieve this goal I will:'
-        + '\n'+this.state.goalPlan);
+        // 'My Goal is:\n'
+        // + this.autosuggestTextarea.textarea.value
+        // + '\n\nThe goal is important to me because:'
+        // + '\n'+this.state.goalImportance
+        // + '\n\nTo achieve this goal I will:'
+        // + '\n'+this.state.goalPlan);
+        this.state.goal+','+this.state.goalImportance+','+this.state.goalPlan);
     }
 
     this.props.onSubmit(this.context.router ? this.context.router.history : null);
@@ -323,9 +329,9 @@ class ComposeForm extends ImmutablePureComponent {
         {goal &&  //TODO update this to be the goal form
         <AutosuggestTextarea
           ref={this.setAutosuggestTextarea}
-          placeholder='my goal is...'
-          disabled={disabled}
-          value={this.props.text}
+          placeholder='My goal is...'
+          disabled
+          value={'Create Your Goal'}
           onChange={this.handleChange}
           suggestions={this.props.suggestions}
           onFocus={this.handleFocus}
@@ -339,7 +345,7 @@ class ComposeForm extends ImmutablePureComponent {
         >
           <EmojiPickerDropdown onPickEmoji={this.handleEmojiPick} />
           <div className='compose-form__modifiers'>
-            <GoalForm handleGoalImportanceChange={this.handleGoalImportanceChange} handleGoalPlanChange={this.handleGoalPlanChange}/>
+            <GoalForm handleGoalChange={this.handleGoalChange} handleGoalImportanceChange={this.handleGoalImportanceChange} handleGoalPlanChange={this.handleGoalPlanChange}/>
             <UploadFormContainer />
             <PollFormContainer />
           </div>

--- a/app/javascript/mastodon/features/compose/components/compose_form.js
+++ b/app/javascript/mastodon/features/compose/components/compose_form.js
@@ -51,16 +51,6 @@ class ComposeForm extends ImmutablePureComponent {
     this.masoCommunity = React.createRef();
     this.futureSelfContainer = React.createRef();
   }
-  state = {
-    tagString: this.DEFAULT_TAG_STRING,
-    futureSelf: false,
-    hasTag: false,
-    hasImage: false,
-    hasText: false,
-    goal: '',
-    goalImportance: '',
-    goalPlan: '',
-  };
 
   static contextTypes = {
     router: PropTypes.object,
@@ -94,6 +84,17 @@ class ComposeForm extends ImmutablePureComponent {
 
   static defaultProps = {
     showSearch: false,
+  };
+
+  state = {
+    tagString: this.DEFAULT_TAG_STRING,
+    futureSelf: false,
+    hasTag: false,
+    hasImage: false,
+    hasText: false,
+    goal: '',
+    goalImportance: '',
+    goalPlan: '',
   };
 
   handleChange = (e) => {
@@ -325,6 +326,7 @@ class ComposeForm extends ImmutablePureComponent {
   }
 
   render () {
+    // alert(this.props.futureSelf);
     const { intl, onPaste, showSearch, anyMedia, goal } = this.props;
     const disabled = this.props.isSubmitting;
     const text     = [this.props.spoilerText, countableText(this.props.text)].join('');
@@ -435,11 +437,11 @@ class ComposeForm extends ImmutablePureComponent {
             <PollButtonContainer />
             <PrivacyDropdownContainer />
             {/*<FutureSelfMenu onClick={this.showFutureSelf} />*/}
-            <FutureSelfContainer disabled={goal} onClick={this.showFutureSelf} ref={this.futureSelfContainer} />
+            <FutureSelfContainer disabled={goal} active={this.props.futureSelf} onClick={this.showFutureSelf} ref={this.futureSelfContainer} />
           </div>
           <div className='character-counter__wrapper'><CharacterCounter max={500} text={text + this.goalText()} /></div>
         </div>
-        {this.state.futureSelf && <div>
+        {(this.state.futureSelf || this.props.futureSelf) && <div>
           <div class='compose-form__buttons-wrapper-bridges'>
             <MasoButton value={'family'} onClick={this.updateTootTag} ref={this.masoFamily} bgColor={['#E8F8F7', '#14BBB0']}  />
             <MasoButton value={'career'} onClick={this.updateTootTag} ref={this.masoCareer} bgColor={['#FDE6F4', '#EA088D']} />

--- a/app/javascript/mastodon/features/compose/components/compose_form.js
+++ b/app/javascript/mastodon/features/compose/components/compose_form.js
@@ -162,10 +162,11 @@ class ComposeForm extends ImmutablePureComponent {
     }
 
     // Submit disabled:
-    const { isSubmitting, isChangingUpload, isUploading, anyMedia } = this.props;
+    const { isSubmitting, isChangingUpload, isUploading, anyMedia, goal} = this.props;
     const fulltext = [this.props.spoilerText, countableText(this.props.text)].join('');
-
-    if (isSubmitting || isUploading || isChangingUpload || length(fulltext) > 500 || (fulltext.length !== 0 && fulltext.trim().length === 0 && !anyMedia)) {
+    if (isSubmitting || isUploading || isChangingUpload || length(fulltext) > 500 || (fulltext.length !== 0 && fulltext.trim().length === 0 && !anyMedia)
+      || (goal && length(fulltext) + (500 - 423) > 500) || (goal && (length(this.autosuggestTextarea.textarea.value) === 0
+      || length(this.state.goalImportance) === 0 || length(this.state.goalPlan) === 0))) {
       return;
     }
 
@@ -180,7 +181,7 @@ class ComposeForm extends ImmutablePureComponent {
       this.resetMastoButton();
     }
 
-    if (this.props.goal) {
+    if (goal) {
       this.props.onChange(
         'My Goal:\n'
         + this.autosuggestTextarea.textarea.value
@@ -189,8 +190,7 @@ class ComposeForm extends ImmutablePureComponent {
         + '\n\nTo achieve this goal I will:'
         + '\n'+this.state.goalPlan);
     }
-    // this.setState({futureSelf: false});
-    // this.props.futureSelf = false;
+
     this.props.onSubmit(this.context.router ? this.context.router.history : null);
   }
 
@@ -377,7 +377,7 @@ class ComposeForm extends ImmutablePureComponent {
             {/*<FutureSelfMenu onClick={this.showFutureSelf} />*/}
             <FutureSelfContainer disabled={goal} onClick={this.showFutureSelf} ref={this.futureSelfContainer} />
           </div>
-          <div className='character-counter__wrapper'><CharacterCounter max={500} text={text} /></div>
+          <div className='character-counter__wrapper'><CharacterCounter max={goal ? 400 : 500} text={text} /></div>
         </div>
         {this.state.futureSelf && <div>
           <div class='compose-form__buttons-wrapper-bridges'>

--- a/app/javascript/mastodon/features/compose/components/compose_form.js
+++ b/app/javascript/mastodon/features/compose/components/compose_form.js
@@ -147,6 +147,13 @@ class ComposeForm extends ImmutablePureComponent {
     }
   }
 
+
+  resetGoal = () => {
+    this.setState({ goal: '' });
+    this.setState({ goalImportance: '' });
+    this.setState({ goalPlan: '' });
+  }
+
   handleGoalChange = e => {
     this.setState({ goal: e.target.value });
   };
@@ -159,6 +166,12 @@ class ComposeForm extends ImmutablePureComponent {
     this.setState({ goalPlan: e.target.value });
   };
 
+  goalText = () => {
+    if(this.props.goal)
+      return this.state.goal+','+this.state.goalImportance+','+this.state.goalPlan;
+    return '';
+  }
+
   handleSubmit = () => {
     if (this.props.text !== this.autosuggestTextarea.textarea.value) {
       // Something changed the text inside the textarea (e.g. browser extensions like Grammarly)
@@ -170,7 +183,7 @@ class ComposeForm extends ImmutablePureComponent {
     const { isSubmitting, isChangingUpload, isUploading, anyMedia, goal} = this.props;
     const fulltext = [this.props.spoilerText, countableText(this.props.text)].join('');
     if (isSubmitting || isUploading || isChangingUpload || length(fulltext) > 500 || (fulltext.length !== 0 && fulltext.trim().length === 0 && !anyMedia)
-      || (goal && length(fulltext) + (500 - 423) > 500) || (goal && (length(this.autosuggestTextarea.textarea.value) === 0
+      || (goal && (length(this.autosuggestTextarea.textarea.value) === 0 || length(this.state.goal) === 0
       || length(this.state.goalImportance) === 0 || length(this.state.goalPlan) === 0))) {
       return;
     }
@@ -194,7 +207,8 @@ class ComposeForm extends ImmutablePureComponent {
         // + '\n'+this.state.goalImportance
         // + '\n\nTo achieve this goal I will:'
         // + '\n'+this.state.goalPlan);
-        this.state.goal+','+this.state.goalImportance+','+this.state.goalPlan);
+        this.goalText());
+      this.resetGoal();
     }
 
     this.props.onSubmit(this.context.router ? this.context.router.history : null);
@@ -260,7 +274,35 @@ class ComposeForm extends ImmutablePureComponent {
         this.autosuggestTextarea.textarea.focus();
       }
     }
+
+    // if(this.state.goal === '' && this.props.goal && this.props.text.value !== '')
+    //   this.parseGoal(this.props.text.value);
   }
+
+  // /**
+  //  * 'My Goal is:\n'
+  //  + this.autosuggestTextarea.textarea.value
+  //  + '\n\nThe goal is important to me because:'
+  //  + '\n'+this.state.goalImportance
+  //  + '\n\nTo achieve this goal I will:'
+  //  + '\n'+this.state.goalPlan);
+  //  * @param text
+  //  */
+  // parseGoal = (text) => {
+  //   try {
+  //     // alert(text);
+  //     // text = text.slice(3,-4); //remove the <p></p>
+  //     let goalStrings = text.split(',');
+  //     alert(goalStrings);
+  //     this.setState({ goal: goalStrings[0] });
+  //     this.setState({ goalImportance: goalStrings[1] });
+  //     this.setState({ goalPlan: goalStrings[2] });
+  //   } catch (e) {
+  //     this.setState({ goal: 'oops there' });
+  //     this.setState({ goalImportance: 'was an error' });
+  //     this.setState({ goalPlan: e });
+  //   }
+  // }
 
   setAutosuggestTextarea = (c) => {
     this.autosuggestTextarea = c;
@@ -299,9 +341,14 @@ class ComposeForm extends ImmutablePureComponent {
     this.checkFutureSelfReqs(anyMedia, text);
     if(goal)
       this.resetMastoButton();
+    else
+      this.resetGoal()
     // this.setState({ hasImage: anyMedia });
     // this.setState({ hasTag: this.state.tagString !== this.DEFAULT_TAG_STRING });
     // console.log(JSON.stringify(intl, null, 2));
+    // if(this.state.goal === '' && goal && this.props.text !== '')
+    //   this.parseGoal(this.props.text); // TODO
+
     return (
       <div className='compose-form'>
         <WarningContainer />
@@ -345,7 +392,14 @@ class ComposeForm extends ImmutablePureComponent {
         >
           <EmojiPickerDropdown onPickEmoji={this.handleEmojiPick} />
           <div className='compose-form__modifiers'>
-            <GoalForm handleGoalChange={this.handleGoalChange} handleGoalImportanceChange={this.handleGoalImportanceChange} handleGoalPlanChange={this.handleGoalPlanChange}/>
+            <GoalForm
+              goal={this.state.goal}
+              goalImportance={this.state.goalImportance}
+              goalPlan={this.state.goalPlan}
+              handleGoalChange={this.handleGoalChange}
+              handleGoalImportanceChange={this.handleGoalImportanceChange}
+              handleGoalPlanChange={this.handleGoalPlanChange}
+            />
             <UploadFormContainer />
             <PollFormContainer />
           </div>
@@ -383,7 +437,7 @@ class ComposeForm extends ImmutablePureComponent {
             {/*<FutureSelfMenu onClick={this.showFutureSelf} />*/}
             <FutureSelfContainer disabled={goal} onClick={this.showFutureSelf} ref={this.futureSelfContainer} />
           </div>
-          <div className='character-counter__wrapper'><CharacterCounter max={goal ? 400 : 500} text={text} /></div>
+          <div className='character-counter__wrapper'><CharacterCounter max={500} text={text + this.goalText()} /></div>
         </div>
         {this.state.futureSelf && <div>
           <div class='compose-form__buttons-wrapper-bridges'>

--- a/app/javascript/mastodon/features/compose/components/compose_form.js
+++ b/app/javascript/mastodon/features/compose/components/compose_form.js
@@ -156,9 +156,9 @@ class ComposeForm extends ImmutablePureComponent {
     }
 
     if (this.state.futureSelf) {
-      this.setState({ hasTag: this.state.tagString !== this.DEFAULT_TAG_STRING })
-      this.setState({ hasImage: anyMedia })
-      this.setState({ hasText: this.autosuggestTextarea.textarea.value.length > 100 })
+      this.setState({ hasTag: this.state.tagString !== this.DEFAULT_TAG_STRING });
+      this.setState({ hasImage: anyMedia });
+      this.setState({ hasText: this.autosuggestTextarea.textarea.value.length > 100 });
       if(this.state.tagString === this.DEFAULT_TAG_STRING || !anyMedia || this.autosuggestTextarea.textarea.value.length < this.FUTURE_SELF_TEXT_THRESHOLD){
         return;
       }
@@ -269,7 +269,7 @@ class ComposeForm extends ImmutablePureComponent {
     this.checkFutureSelfReqs(anyMedia, text);
     // this.setState({ hasImage: anyMedia });
     // this.setState({ hasTag: this.state.tagString !== this.DEFAULT_TAG_STRING });
-
+    // console.log(JSON.stringify(intl, null, 2));
     return (
       <div className='compose-form'>
         <WarningContainer />
@@ -293,8 +293,33 @@ class ComposeForm extends ImmutablePureComponent {
             className='spoiler-input__input'
           />
         </div>
-
+        {/*if we are drafting a goal show goal form*/}
+        {this.props.goal && //TODO update this to be the goal form
         <AutosuggestTextarea
+          ref={this.setAutosuggestTextarea}
+          placeholder="what's your goal?"
+          disabled={disabled}
+          value={this.props.text}
+          onChange={this.handleChange}
+          suggestions={this.props.suggestions}
+          onFocus={this.handleFocus}
+          onKeyDown={this.handleKeyDown}
+          onSuggestionsFetchRequested={this.onSuggestionsFetchRequested}
+          onSuggestionsClearRequested={this.onSuggestionsClearRequested}
+          onSuggestionSelected={this.onSuggestionSelected}
+          onPaste={onPaste}
+          autoFocus={!showSearch && !isMobile(window.innerWidth)}
+          goal
+        >
+          <EmojiPickerDropdown onPickEmoji={this.handleEmojiPick} />
+          <div className='compose-form__modifiers'>
+            <UploadFormContainer />
+            <PollFormContainer />
+          </div>
+        </AutosuggestTextarea>
+        }
+        {/*otherwise be a normal text area*/}
+        {!this.props.goal && <AutosuggestTextarea
           ref={this.setAutosuggestTextarea}
           placeholder={intl.formatMessage(messages.placeholder)}
           disabled={disabled}
@@ -314,7 +339,7 @@ class ComposeForm extends ImmutablePureComponent {
             <UploadFormContainer />
             <PollFormContainer />
           </div>
-        </AutosuggestTextarea>
+        </AutosuggestTextarea> }
 
 
         <div className='compose-form__buttons-wrapper'>
@@ -339,7 +364,7 @@ class ComposeForm extends ImmutablePureComponent {
           {!this.state.hasImage && <div>
             <CheckButton />
             add an image of your future self.
-            </div>}
+          </div>}
           {this.state.hasImage && <div>
             <CheckButton icon='check' />
             add an image of your future self. </div>}
@@ -369,7 +394,8 @@ class ComposeForm extends ImmutablePureComponent {
                 && (!this.state.hasImage //TODO
                   || !this.state.hasTag
                   || !this.state.hasText))}
-              block />
+              block
+            />
           </div>
         </div>
       </div>

--- a/app/javascript/mastodon/features/compose/components/future_self.js
+++ b/app/javascript/mastodon/features/compose/components/future_self.js
@@ -10,7 +10,7 @@ export default class FutureSelfMenu extends React.PureComponent {
     disabled: PropTypes.bool.isRequired,
   };
 
-  state = { i: 0, active: false }
+  state = { i: 0, active: this.props.active || false }
 
   handleClick = (e) => {
     e.preventDefault();

--- a/app/javascript/mastodon/features/compose/components/future_self.js
+++ b/app/javascript/mastodon/features/compose/components/future_self.js
@@ -7,6 +7,7 @@ export default class FutureSelfMenu extends React.PureComponent {
   static propTypes = {
     onClick: PropTypes.func.isRequired,
     onChange: PropTypes.func.isRequired,
+    disabled: PropTypes.bool.isRequired,
   };
 
   state = { i: 0, active: false }
@@ -35,6 +36,7 @@ export default class FutureSelfMenu extends React.PureComponent {
   render () {
     return (
       <IconButton
+        disabled={this.props.disabled}
         icon={this.options[this.state.i % this.options.length].icon} //need to figure out where to put our images so this works.
         title={'future_self'}
         size={18}

--- a/app/javascript/mastodon/features/compose/components/goal_form.js
+++ b/app/javascript/mastodon/features/compose/components/goal_form.js
@@ -14,17 +14,14 @@ class GoalForm extends ImmutablePureComponent {
     suggestions: ImmutablePropTypes.list,
     disabled: PropTypes.bool,
     placeholder: PropTypes.string,
-    onSuggestionSelected: PropTypes.func.isRequired,
-    onSuggestionsClearRequested: PropTypes.func.isRequired,
-    onSuggestionsFetchRequested: PropTypes.func.isRequired,
-    onChange: PropTypes.func.isRequired,
+    onChange: PropTypes.func,
     onKeyUp: PropTypes.func,
     onKeyDown: PropTypes.func,
     autoFocus: PropTypes.bool,
     className: PropTypes.string,
     id: PropTypes.string,
-    searchTokens: PropTypes.arrayOf(PropTypes.string),
     maxLength: PropTypes.number,
+    handleGoalChange: PropTypes.func.isRequired,
     handleGoalImportanceChange: PropTypes.func.isRequired,
     handleGoalPlanChange: PropTypes.func.isRequired,
   };
@@ -201,7 +198,7 @@ class GoalForm extends ImmutablePureComponent {
                         style={styleB}
                         aria-autocomplete='list'
                         id={'goalImportance'}
-                        resize
+                        // resize
                         // className='input-copy'
                         // maxLength={25}
                       />

--- a/app/javascript/mastodon/features/compose/components/goal_form.js
+++ b/app/javascript/mastodon/features/compose/components/goal_form.js
@@ -45,9 +45,9 @@ class GoalForm extends ImmutablePureComponent {
   };
 
   state = {
-    goal: '',
-    goalImportance: '',
-    goalPlan: '',
+    goal: this.props.goal || '',
+    goalImportance: this.props.goalImportance || '',
+    goalPlan: this.props.goalPlan || '',
   }
 
 
@@ -80,7 +80,7 @@ class GoalForm extends ImmutablePureComponent {
                       onBlur={this.onBlur}
                       style={styleA}
                       aria-autocomplete='list'
-                      id={'goal'}
+                      id={'goalInput'}
                       // className='input-copy'
                       // maxLength={25}
                     />
@@ -108,7 +108,7 @@ class GoalForm extends ImmutablePureComponent {
                       onBlur={this.onBlur}
                       style={styleA}
                       aria-autocomplete='list'
-                      id={'goalImportance'}
+                      id={'goalImportanceInput'}
                       // className='input-copy'
                       // maxLength={25}
                     />
@@ -136,7 +136,7 @@ class GoalForm extends ImmutablePureComponent {
                       onBlur={this.onBlur}
                       style={styleA}
                       aria-autocomplete='list'
-                      id={'goalPlan'}
+                      id={'goalPlanInput'}
                       // className='input-copy'
                       // maxLength={25}
                     />

--- a/app/javascript/mastodon/features/compose/components/goal_form.js
+++ b/app/javascript/mastodon/features/compose/components/goal_form.js
@@ -1,0 +1,116 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import ImmutablePureComponent from 'react-immutable-pure-component';
+import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
+import Textarea from 'react-textarea-autosize';
+
+export default
+@injectIntl
+class GoalForm extends ImmutablePureComponent {
+
+  static propTypes = {
+    value: PropTypes.string,
+    suggestions: ImmutablePropTypes.list,
+    disabled: PropTypes.bool,
+    placeholder: PropTypes.string,
+    onSuggestionSelected: PropTypes.func.isRequired,
+    onSuggestionsClearRequested: PropTypes.func.isRequired,
+    onSuggestionsFetchRequested: PropTypes.func.isRequired,
+    onChange: PropTypes.func.isRequired,
+    onKeyUp: PropTypes.func,
+    onKeyDown: PropTypes.func,
+    autoFocus: PropTypes.bool,
+    className: PropTypes.string,
+    id: PropTypes.string,
+    searchTokens: PropTypes.arrayOf(PropTypes.string),
+    maxLength: PropTypes.number,
+    handleGoalImportanceChange: PropTypes.func.isRequired,
+    handleGoalPlanChange: PropTypes.func.isRequired,
+  };
+
+  handleGoalImportanceChange = e => {
+    this.setState({ goalImportance: e.target.value });
+    this.props.handleGoalImportanceChange(e);
+  };
+
+  handleGoalPlanChange = e => {
+    this.setState({ goalPlan: e.target.value });
+    this.props.handleGoalPlanChange(e);
+  };
+
+  state = {
+    goalImportance: '',
+    goalPlan: '',
+  }
+
+
+  render () {
+    const { value, suggestions, disabled, placeholder, onKeyUp, autoFocus, className, id, maxLength } = this.props;
+    const style = { direction: 'ltr', backgroundColor:'rgba(0,0,0,0)', marginBottom: 10, color:'#272b37', fontSize: 14 };
+
+    return (
+      <div className='form-container'>
+        <form className='simple_form'>
+          <div className='fields-group'>
+            <div className='input with_label'>
+              <div className='label_input'>
+                <label style={{ color:'#272b37' }}>
+                The goal is important to me because:
+                </label>
+                <div className='label_input__wrapper'>
+                  <Textarea
+                    type='text'
+                    ref={this.setInput}
+                    disabled={false}
+                    placeholder={'...'}
+                    value={this.state.goalImportance}
+                    onChange={this.handleGoalImportanceChange}
+                    onKeyDown={this.onKeyDown}
+                    onKeyUp={onKeyUp}
+                    onFocus={this.onFocus}
+                    onBlur={this.onBlur}
+                    style={style}
+                    aria-autocomplete='list'
+                    id={'goalImportance'}
+                    // className='input-copy'
+                    // maxLength={25}
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div className='fields-group'>
+            <div className='input with_label'>
+              <div className='label_input'>
+                <label style={{ color:'#272b37' }}>
+                  The achieve this goal I will:
+                </label>
+                <div className='label_input__wrapper'>
+                  <Textarea
+                    type='text'
+                    ref={this.setInput}
+                    disabled={false}
+                    placeholder={'...'}
+                    value={this.state.goalPlan}
+                    onChange={this.handleGoalPlanChange}
+                    onKeyDown={this.onKeyDown}
+                    onKeyUp={onKeyUp}
+                    onFocus={this.onFocus}
+                    onBlur={this.onBlur}
+                    style={style}
+                    aria-autocomplete='list'
+                    id={'goalPlan'}
+                    // className='input-copy'
+                    // maxLength={25}
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </form>
+      </div>
+    );
+  }
+
+}

--- a/app/javascript/mastodon/features/compose/components/goal_form.js
+++ b/app/javascript/mastodon/features/compose/components/goal_form.js
@@ -84,7 +84,7 @@ class GoalForm extends ImmutablePureComponent {
             <div className='input with_label'>
               <div className='label_input'>
                 <label style={{ color:'#272b37' }}>
-                  The achieve this goal I will:
+                  To achieve this goal I will:
                 </label>
                 <div className='label_input__wrapper'>
                   <Textarea

--- a/app/javascript/mastodon/features/compose/components/goal_form.js
+++ b/app/javascript/mastodon/features/compose/components/goal_form.js
@@ -39,7 +39,13 @@ class GoalForm extends ImmutablePureComponent {
     this.props.handleGoalPlanChange(e);
   };
 
+  handleGoalChange = e => {
+    this.setState({ goal: e.target.value });
+    this.props.handleGoalChange(e);
+  };
+
   state = {
+    goal: '',
     goalImportance: '',
     goalPlan: '',
   }
@@ -47,70 +53,195 @@ class GoalForm extends ImmutablePureComponent {
 
   render () {
     const { value, suggestions, disabled, placeholder, onKeyUp, autoFocus, className, id, maxLength } = this.props;
-    const style = { direction: 'ltr', backgroundColor:'rgba(0,0,0,0)', marginBottom: 10, color:'#272b37', fontSize: 14 };
+    const styleA = { direction: 'ltr', backgroundColor:'rgba(0,0,0,0)', marginBottom: 10, color:'#272b37', fontSize: 14 };
+    const styleB = { direction: 'ltr', fontSize: 14, resize: 'none'};
 
-    return (
-      <div className='form-container'>
-        <form className='simple_form'>
-          <div className='fields-group'>
-            <div className='input with_label'>
-              <div className='label_input'>
-                <label style={{ color:'#272b37' }}>
-                The goal is important to me because:
-                </label>
-                <div className='label_input__wrapper'>
-                  <Textarea
-                    type='text'
-                    ref={this.setInput}
-                    disabled={false}
-                    placeholder={'...'}
-                    value={this.state.goalImportance}
-                    onChange={this.handleGoalImportanceChange}
-                    onKeyDown={this.onKeyDown}
-                    onKeyUp={onKeyUp}
-                    onFocus={this.onFocus}
-                    onBlur={this.onBlur}
-                    style={style}
-                    aria-autocomplete='list'
-                    id={'goalImportance'}
-                    // className='input-copy'
-                    // maxLength={25}
-                  />
+    if(!this.props.display || null) {
+      return (
+        <div className='form-container'>
+          <form className='simple_form'>
+            <div className='fields-group'>
+              <div className='input with_label'>
+                <div className='label_input'>
+                  <label style={{ color: '#272b37' }}>
+                    My Goal is:
+                  </label>
+                  <div className='label_input__wrapper'>
+                    <Textarea
+                      type='text'
+                      ref={this.setInput}
+                      disabled={false}
+                      placeholder={'...'}
+                      value={this.state.goal}
+                      onChange={this.handleGoalChange}
+                      onKeyDown={this.onKeyDown}
+                      onKeyUp={onKeyUp}
+                      onFocus={this.onFocus}
+                      onBlur={this.onBlur}
+                      style={styleA}
+                      aria-autocomplete='list'
+                      id={'goal'}
+                      // className='input-copy'
+                      // maxLength={25}
+                    />
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-          <div className='fields-group'>
-            <div className='input with_label'>
-              <div className='label_input'>
-                <label style={{ color:'#272b37' }}>
-                  To achieve this goal I will:
-                </label>
-                <div className='label_input__wrapper'>
-                  <Textarea
-                    type='text'
-                    ref={this.setInput}
-                    disabled={false}
-                    placeholder={'...'}
-                    value={this.state.goalPlan}
-                    onChange={this.handleGoalPlanChange}
-                    onKeyDown={this.onKeyDown}
-                    onKeyUp={onKeyUp}
-                    onFocus={this.onFocus}
-                    onBlur={this.onBlur}
-                    style={style}
-                    aria-autocomplete='list'
-                    id={'goalPlan'}
-                    // className='input-copy'
-                    // maxLength={25}
-                  />
+            <div className='fields-group'>
+              <div className='input with_label'>
+                <div className='label_input'>
+                  <label style={{ color: '#272b37' }}>
+                    The goal is important to me because:
+                  </label>
+                  <div className='label_input__wrapper'>
+                    <Textarea
+                      type='text'
+                      ref={this.setInput}
+                      disabled={false}
+                      placeholder={'...'}
+                      value={this.state.goalImportance}
+                      onChange={this.handleGoalImportanceChange}
+                      onKeyDown={this.onKeyDown}
+                      onKeyUp={onKeyUp}
+                      onFocus={this.onFocus}
+                      onBlur={this.onBlur}
+                      style={styleA}
+                      aria-autocomplete='list'
+                      id={'goalImportance'}
+                      // className='input-copy'
+                      // maxLength={25}
+                    />
+                  </div>
                 </div>
               </div>
             </div>
+            <div className='fields-group'>
+              <div className='input with_label'>
+                <div className='label_input'>
+                  <label style={{ color: '#272b37' }}>
+                    To achieve this goal I will:
+                  </label>
+                  <div className='label_input__wrapper'>
+                    <Textarea
+                      type='text'
+                      ref={this.setInput}
+                      disabled={false}
+                      placeholder={'...'}
+                      value={this.state.goalPlan}
+                      onChange={this.handleGoalPlanChange}
+                      onKeyDown={this.onKeyDown}
+                      onKeyUp={onKeyUp}
+                      onFocus={this.onFocus}
+                      onBlur={this.onBlur}
+                      style={styleA}
+                      aria-autocomplete='list'
+                      id={'goalPlan'}
+                      // className='input-copy'
+                      // maxLength={25}
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </form>
+        </div>
+      );
+    } else {
+      {
+        return (
+          <div className='form-container'>
+            <form className='simple_form'>
+              <div className='fields-group'>
+                <div className='input with_label'>
+                  <div className='label_input'>
+                    <label>
+                      My Goal is:
+                    </label>
+                    <div className='label_input__wrapper'>
+                      <Textarea
+                        type='text'
+                        ref={this.setInput}
+                        disabled
+                        placeholder={'...'}
+                        value={this.props.goal}
+                        onChange={this.handleGoalChange}
+                        onKeyDown={this.onKeyDown}
+                        onKeyUp={onKeyUp}
+                        onFocus={this.onFocus}
+                        onBlur={this.onBlur}
+                        style={styleB}
+                        aria-autocomplete='list'
+                        id={'goal'}
+                        // className='input-copy'
+                        // maxLength={25}
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div className='fields-group'>
+                <div className='input with_label'>
+                  <div className='label_input'>
+                    <label>
+                      The goal is important to me because:
+                    </label>
+                    <div className='label_input__wrapper'>
+                      <Textarea
+                        type='text'
+                        ref={this.setInput}
+                        disabled
+                        placeholder={'...'}
+                        value={this.props.goalImportance}
+                        onChange={this.handleGoalImportanceChange}
+                        onKeyDown={this.onKeyDown}
+                        onKeyUp={onKeyUp}
+                        onFocus={this.onFocus}
+                        onBlur={this.onBlur}
+                        style={styleB}
+                        aria-autocomplete='list'
+                        id={'goalImportance'}
+                        resize
+                        // className='input-copy'
+                        // maxLength={25}
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div className='fields-group'>
+                <div className='input with_label'>
+                  <div className='label_input'>
+                    <label>
+                      To achieve this goal I will:
+                    </label>
+                    <div className='label_input__wrapper'>
+                      <Textarea
+                        type='text'
+                        ref={this.setInput}
+                        disabled
+                        placeholder={'...'}
+                        value={this.props.goalPlan}
+                        onChange={this.handleGoalPlanChange}
+                        onKeyDown={this.onKeyDown}
+                        onKeyUp={onKeyUp}
+                        onFocus={this.onFocus}
+                        onBlur={this.onBlur}
+                        style={styleB}
+                        aria-autocomplete='list'
+                        id={'goalPlan'}
+                        // className='input-copy'
+                        // maxLength={25}
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </form>
           </div>
-        </form>
-      </div>
-    );
+        );
+      }
+    }
   }
 
 }

--- a/app/javascript/mastodon/features/compose/components/goal_form.js
+++ b/app/javascript/mastodon/features/compose/components/goal_form.js
@@ -54,7 +54,7 @@ class GoalForm extends ImmutablePureComponent {
   render () {
     const { value, suggestions, disabled, placeholder, onKeyUp, autoFocus, className, id, maxLength } = this.props;
     const styleA = { direction: 'ltr', backgroundColor:'rgba(0,0,0,0)', marginBottom: 10, color:'#272b37', fontSize: 14 };
-    const styleB = { direction: 'ltr', fontSize: 14, resize: 'none'};
+    const styleB = { direction: 'ltr', fontSize: 14, resize: 'none', backgroundColor: 'rgba(0,0,0,.2)', /*border: 'none', outlineColor: 'rgba(0,0,0,.25)'*/};
 
     if(!this.props.display || null) {
       return (

--- a/app/javascript/mastodon/features/compose/components/goal_form.js
+++ b/app/javascript/mastodon/features/compose/components/goal_form.js
@@ -21,9 +21,9 @@ class GoalForm extends ImmutablePureComponent {
     className: PropTypes.string,
     id: PropTypes.string,
     maxLength: PropTypes.number,
-    handleGoalChange: PropTypes.func.isRequired,
-    handleGoalImportanceChange: PropTypes.func.isRequired,
-    handleGoalPlanChange: PropTypes.func.isRequired,
+    handleGoalChange: PropTypes.func,
+    handleGoalImportanceChange: PropTypes.func,
+    handleGoalPlanChange: PropTypes.func,
   };
 
   handleGoalImportanceChange = e => {

--- a/app/javascript/mastodon/features/compose/containers/compose_form_container.js
+++ b/app/javascript/mastodon/features/compose/containers/compose_form_container.js
@@ -18,6 +18,7 @@ const mapStateToProps = state => ({
   spoilerText: state.getIn(['compose', 'spoiler_text']),
   privacy: state.getIn(['compose', 'privacy']),
   futureSelf: state.getIn(['compose', 'futureSelf']),
+  goal: state.getIn(['compose', 'goal']),
   focusDate: state.getIn(['compose', 'focusDate']),
   caretPosition: state.getIn(['compose', 'caretPosition']),
   preselectDate: state.getIn(['compose', 'preselectDate']),

--- a/app/javascript/mastodon/features/status/components/action_bar.js
+++ b/app/javascript/mastodon/features/status/components/action_bar.js
@@ -41,6 +41,7 @@ class ActionBar extends React.PureComponent {
   static propTypes = {
     status: ImmutablePropTypes.map.isRequired,
     onReply: PropTypes.func.isRequired,
+    onGoal: PropTypes.func.isRequired,
     onReblog: PropTypes.func.isRequired,
     onFavourite: PropTypes.func.isRequired,
     onDelete: PropTypes.func.isRequired,
@@ -61,7 +62,7 @@ class ActionBar extends React.PureComponent {
 
   handleGoalClick = () => {
     if (me) {
-      this.props.onReply(this.props.status, this.context.router.history);
+      this.props.onGoal(this.props.status);
     } else {
       throw new Error('unable to create a goal for a post that is not recognized as your own.');
     }
@@ -203,13 +204,14 @@ class ActionBar extends React.PureComponent {
 
     let goalIcon = 'flag';
     let goalTitle = 'create goal';
-
+    console.log(JSON.stringify(status, null, 2));
+    console.log(JSON.stringify(intl, null, 2));
     return (
       <div className='detailed-status__action-bar'>
         <div className='detailed-status__button'><IconButton title={intl.formatMessage(messages.reply)} icon={status.get('in_reply_to_account_id') === status.getIn(['account', 'id']) ? 'reply' : replyIcon} onClick={this.handleReplyClick} /></div>
         <div className='detailed-status__button'><IconButton disabled={reblog_disabled} active={status.get('reblogged')} title={reblog_disabled ? intl.formatMessage(messages.cannot_reblog) : intl.formatMessage(messages.reblog)} icon={reblogIcon} onClick={this.handleReblogClick} /></div>
         <div className='detailed-status__button'><IconButton className='star-icon' animate active={status.get('favourited')} title={intl.formatMessage(messages.favourite)} icon='star' onClick={this.handleFavouriteClick} /></div>
-        {status.get('futureself') && <div className='detailed-status__button'><IconButton className='status__action-bar-button' title={goalTitle} icon={goalIcon} onClick={this.handleGoalClick} /></div>}
+        {status.get('futureself') && status.getIn(['account', 'id']) === `${me}` && <div className='detailed-status__button'><IconButton className='status__action-bar-button' title={goalTitle} icon={goalIcon} onClick={this.handleGoalClick} /></div>}
         {shareButton}
 
         <div className='detailed-status__action-bar-dropdown'>

--- a/app/javascript/mastodon/features/status/components/action_bar.js
+++ b/app/javascript/mastodon/features/status/components/action_bar.js
@@ -204,8 +204,8 @@ class ActionBar extends React.PureComponent {
 
     let goalIcon = 'flag';
     let goalTitle = 'create goal';
-    console.log(JSON.stringify(status, null, 2));
-    console.log(JSON.stringify(intl, null, 2));
+    // console.log(JSON.stringify(status, null, 2));
+    // console.log(JSON.stringify(intl, null, 2));
     return (
       <div className='detailed-status__action-bar'>
         <div className='detailed-status__button'><IconButton title={intl.formatMessage(messages.reply)} icon={status.get('in_reply_to_account_id') === status.getIn(['account', 'id']) ? 'reply' : replyIcon} onClick={this.handleReplyClick} /></div>

--- a/app/javascript/mastodon/features/status/components/action_bar.js
+++ b/app/javascript/mastodon/features/status/components/action_bar.js
@@ -59,6 +59,14 @@ class ActionBar extends React.PureComponent {
     this.props.onReply(this.props.status);
   }
 
+  handleGoalClick = () => {
+    if (me) {
+      this.props.onReply(this.props.status, this.context.router.history);
+    } else {
+      throw new Error('unable to create a goal for a post that is not recognized as your own.');
+    }
+  }
+
   handleReblogClick = (e) => {
     this.props.onReblog(this.props.status, e);
   }
@@ -193,11 +201,15 @@ class ActionBar extends React.PureComponent {
 
     let reblog_disabled = (status.get('visibility') === 'direct' || status.get('visibility') === 'private');
 
+    let goalIcon = 'flag';
+    let goalTitle = 'create goal';
+
     return (
       <div className='detailed-status__action-bar'>
         <div className='detailed-status__button'><IconButton title={intl.formatMessage(messages.reply)} icon={status.get('in_reply_to_account_id') === status.getIn(['account', 'id']) ? 'reply' : replyIcon} onClick={this.handleReplyClick} /></div>
         <div className='detailed-status__button'><IconButton disabled={reblog_disabled} active={status.get('reblogged')} title={reblog_disabled ? intl.formatMessage(messages.cannot_reblog) : intl.formatMessage(messages.reblog)} icon={reblogIcon} onClick={this.handleReblogClick} /></div>
         <div className='detailed-status__button'><IconButton className='star-icon' animate active={status.get('favourited')} title={intl.formatMessage(messages.favourite)} icon='star' onClick={this.handleFavouriteClick} /></div>
+        {status.get('futureself') && <div className='detailed-status__button'><IconButton className='status__action-bar-button' title={goalTitle} icon={goalIcon} onClick={this.handleGoalClick} /></div>}
         {shareButton}
 
         <div className='detailed-status__action-bar-dropdown'>

--- a/app/javascript/mastodon/features/status/components/detailed_status.js
+++ b/app/javascript/mastodon/features/status/components/detailed_status.js
@@ -14,6 +14,7 @@ import Audio from '../../audio';
 import scheduleIdleTask from '../../ui/util/schedule_idle_task';
 import classNames from 'classnames';
 import Icon from 'mastodon/components/icon';
+import IconButton from "../../../components/icon_button";
 
 export default class DetailedStatus extends ImmutablePureComponent {
 
@@ -206,6 +207,7 @@ export default class DetailedStatus extends ImmutablePureComponent {
         </a>
       );
     }
+
 
     return (
       <div style={outerStyle}>

--- a/app/javascript/mastodon/features/status/index.js
+++ b/app/javascript/mastodon/features/status/index.js
@@ -22,6 +22,7 @@ import {
   replyCompose,
   mentionCompose,
   directCompose,
+  goalCompose,
 } from '../../actions/compose';
 import {
   muteStatus,
@@ -216,6 +217,19 @@ class Status extends ImmutablePureComponent {
     }
   }
 
+  handleGoalClick = (status) => {
+    let { askReplyConfirmation, dispatch, intl } = this.props;
+    if (askReplyConfirmation) {
+      dispatch(openModal('CONFIRM', {
+        message: intl.formatMessage(messages.replyMessage),
+        confirm: intl.formatMessage(messages.replyConfirm),
+        onConfirm: () => dispatch(goalCompose(status, this.context.router.history)),
+      }));
+    } else {
+      dispatch(goalCompose(status, this.context.router.history));
+    }
+  }
+
   handleModalReblog = (status) => {
     this.props.dispatch(reblog(status));
   }
@@ -305,6 +319,14 @@ class Status extends ImmutablePureComponent {
 
   handleEmbed = (status) => {
     this.props.dispatch(openModal('EMBED', { url: status.get('url') }));
+  }
+
+  onModalReblog (status) {
+    if (status.get('reblogged')) {
+      dispatch(unreblog(status));
+    } else {
+      dispatch(reblog(status));
+    }
   }
 
   handleHotkeyMoveUp = () => {
@@ -508,6 +530,7 @@ class Status extends ImmutablePureComponent {
                   onReport={this.handleReport}
                   onPin={this.handlePin}
                   onEmbed={this.handleEmbed}
+                  onGoal={this.handleGoalClick}
                 />
               </div>
             </HotKeys>

--- a/app/javascript/mastodon/reducers/compose.js
+++ b/app/javascript/mastodon/reducers/compose.js
@@ -24,6 +24,7 @@ import {
   COMPOSE_SPOILER_TEXT_CHANGE,
   COMPOSE_VISIBILITY_CHANGE,
   COMPOSE_FUTURE_SELF_CHANGE,
+  COMPOSE_GOAL_CHANGE,
   COMPOSE_COMPOSING_CHANGE,
   COMPOSE_EMOJI_INSERT,
   COMPOSE_UPLOAD_CHANGE_REQUEST,
@@ -52,6 +53,7 @@ const initialState = ImmutableMap({
   spoiler_text: '',
   privacy: null,
   futureSelf: false,
+  goal: false,
   text: '',
   focusDate: null,
   caretPosition: null,
@@ -99,6 +101,7 @@ function clearAll(state) {
     map.set('in_reply_to', null);
     map.set('privacy', state.get('default_privacy'));
     map.set('futureSelf', false);
+    map.set('goal', false);
     map.set('sensitive', false);
     map.update('media_attachments', list => list.clear());
     map.set('poll', null);
@@ -282,6 +285,10 @@ export default function compose(state = initialState, action) {
   case COMPOSE_FUTURE_SELF_CHANGE:
     return state
       .set('futureSelf', action.value)
+      .set('idempotencyKey', uuid());
+  case COMPOSE_GOAL_CHANGE:
+    return state
+      .set('goal', action.value)
       .set('idempotencyKey', uuid());
   case COMPOSE_CHANGE:
     return state

--- a/app/javascript/mastodon/reducers/compose.js
+++ b/app/javascript/mastodon/reducers/compose.js
@@ -404,7 +404,9 @@ export default function compose(state = initialState, action) {
     return state.withMutations(map => {
       //TODO RESOLVE THIS WORK AROUND SO GOALFORM GETS FILLED IN
       if(!action.status.get('goal')) map.set('text', action.raw_text || unescapeHTML(expandMentions(action.status)));
-      map.set('futureSelf', action.status.get('futureSelf'));
+      //TODO fix this for mobile!
+      if(action.status.get('futureself')) map.set('text', action.raw_text.substring(0,action.raw_text.lastIndexOf('#futureSelf')-1) || unescapeHTML(expandMentions(action.status)).substring(0,unescapeHTML(expandMentions(action.status)).lastIndexOf('#futureSelf')-1));
+      map.set('futureSelf', action.status.get('futureself'));
       map.set('goal', action.status.get('goal'));
       map.set('in_reply_to', action.status.get('in_reply_to_id'));
       map.set('privacy', action.status.get('visibility'));

--- a/app/javascript/mastodon/reducers/compose.js
+++ b/app/javascript/mastodon/reducers/compose.js
@@ -24,7 +24,7 @@ import {
   COMPOSE_SPOILER_TEXT_CHANGE,
   COMPOSE_VISIBILITY_CHANGE,
   COMPOSE_FUTURE_SELF_CHANGE,
-  COMPOSE_GOAL_CHANGE,
+  COMPOSE_GOAL,
   COMPOSE_COMPOSING_CHANGE,
   COMPOSE_EMOJI_INSERT,
   COMPOSE_UPLOAD_CHANGE_REQUEST,
@@ -286,10 +286,17 @@ export default function compose(state = initialState, action) {
     return state
       .set('futureSelf', action.value)
       .set('idempotencyKey', uuid());
-  case COMPOSE_GOAL_CHANGE:
-    return state
-      .set('goal', action.value)
-      .set('idempotencyKey', uuid());
+  case COMPOSE_GOAL: // map.set('goal', action.value)
+    return state.withMutations(map => {
+      map.set('goal', true);
+      map.set('in_reply_to', action.status.get('id'));
+      map.set('text', statusToTextMentions(state, action.status));
+      map.set('privacy', privacyPreference('unlisted', state.get('default_privacy')));
+      map.set('focusDate', new Date());
+      map.set('caretPosition', null);
+      map.set('preselectDate', new Date());
+      map.set('idempotencyKey', uuid());
+    });
   case COMPOSE_CHANGE:
     return state
       .set('text', action.text)
@@ -317,6 +324,7 @@ export default function compose(state = initialState, action) {
   case COMPOSE_REPLY_CANCEL:
   case COMPOSE_RESET:
     return state.withMutations(map => {
+      map.set('goal', false);
       map.set('in_reply_to', null);
       map.set('text', '');
       map.set('spoiler', false);

--- a/app/javascript/mastodon/reducers/compose.js
+++ b/app/javascript/mastodon/reducers/compose.js
@@ -402,7 +402,8 @@ export default function compose(state = initialState, action) {
       }));
   case REDRAFT:
     return state.withMutations(map => {
-      map.set('text', action.raw_text || unescapeHTML(expandMentions(action.status)));
+      //TODO RESOLVE THIS WORK AROUND SO GOALFORM GETS FILLED IN
+      if(!action.status.get('goal')) map.set('text', action.raw_text || unescapeHTML(expandMentions(action.status)));
       map.set('futureSelf', action.status.get('futureSelf'));
       map.set('goal', action.status.get('goal'));
       map.set('in_reply_to', action.status.get('in_reply_to_id'));

--- a/app/javascript/mastodon/reducers/compose.js
+++ b/app/javascript/mastodon/reducers/compose.js
@@ -291,9 +291,12 @@ export default function compose(state = initialState, action) {
       map.set('goal', true);
       map.set('in_reply_to', action.status.get('id'));
       map.set('text', statusToTextMentions(state, action.status));
+      // TODO add goalForm
       map.set('privacy', privacyPreference('unlisted', state.get('default_privacy')));
       map.set('focusDate', new Date());
       map.set('caretPosition', null);
+      map.set('poll', null);
+      map.set('futureself', false);
       map.set('preselectDate', new Date());
       map.set('idempotencyKey', uuid());
     });
@@ -331,6 +334,7 @@ export default function compose(state = initialState, action) {
       map.set('spoiler_text', '');
       map.set('privacy', state.get('default_privacy'));
       map.set('poll', null);
+      // TODO add goalForm null
       map.set('idempotencyKey', uuid());
     });
   case COMPOSE_SUBMIT_REQUEST:
@@ -422,6 +426,9 @@ export default function compose(state = initialState, action) {
           expires_in: expiresInFromExpiresAt(action.status.getIn(['poll', 'expires_at'])),
         }));
       }
+
+      // TODO handle reforming GOAL
+      if (action.status.get('goal')) {}
     });
   case COMPOSE_POLL_ADD:
     return state.set('poll', initialPoll);

--- a/app/javascript/mastodon/reducers/compose.js
+++ b/app/javascript/mastodon/reducers/compose.js
@@ -403,6 +403,8 @@ export default function compose(state = initialState, action) {
   case REDRAFT:
     return state.withMutations(map => {
       map.set('text', action.raw_text || unescapeHTML(expandMentions(action.status)));
+      map.set('futureSelf', action.status.get('futureSelf'));
+      map.set('goal', action.status.get('goal'));
       map.set('in_reply_to', action.status.get('in_reply_to_id'));
       map.set('privacy', action.status.get('visibility'));
       map.set('media_attachments', action.status.get('media_attachments'));

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -470,7 +470,7 @@
     }
 
     @media screen and (max-width: 600px) {
-      height: 100px !important; // prevent auto-resize textarea
+      height: 30px !important; // prevent auto-resize textarea
       resize: vertical;
     }
   }

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -406,6 +406,7 @@
     }
   }
 
+  .goal-textarea__textarea,
   .autosuggest-textarea__textarea,
   .spoiler-input__input {
     display: block;
@@ -440,6 +441,24 @@
 
   .autosuggest-textarea__textarea {
     min-height: 100px;
+    border-radius: 4px 4px 0 0;
+    padding-bottom: 0;
+    padding-right: 10px + 22px;
+    resize: none;
+    scrollbar-color: initial;
+
+    &::-webkit-scrollbar {
+      all: unset;
+    }
+
+    @media screen and (max-width: 600px) {
+      height: 100px !important; // prevent auto-resize textarea
+      resize: vertical;
+    }
+  }
+
+  .goal-textarea__textarea {
+    min-height: 10px;
     border-radius: 4px 4px 0 0;
     padding-bottom: 0;
     padding-right: 10px + 22px;

--- a/app/models/backup.rb
+++ b/app/models/backup.rb
@@ -7,7 +7,7 @@
 #  user_id           :bigint(8)
 #  dump_file_name    :string
 #  dump_content_type :string
-#  dump_file_size    :integer
+#  dump_file_size    :bigint(8)
 #  dump_updated_at   :datetime
 #  processed         :boolean          default(FALSE), not null
 #  created_at        :datetime         not null

--- a/app/models/list_account.rb
+++ b/app/models/list_account.rb
@@ -6,7 +6,7 @@
 #  id         :bigint(8)        not null, primary key
 #  list_id    :bigint(8)        not null
 #  account_id :bigint(8)        not null
-#  follow_id  :bigint(8)        not null
+#  follow_id  :bigint(8)
 #
 
 class ListAccount < ApplicationRecord

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -23,6 +23,8 @@
 #  in_reply_to_account_id :bigint(8)
 #  poll_id                :bigint(8)
 #  deleted_at             :datetime
+#  futureself             :boolean
+#  goal                   :boolean
 #
 
 class Status < ApplicationRecord

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,7 +38,8 @@
 #  chosen_languages          :string           is an Array
 #  created_by_application_id :bigint(8)
 #  approved                  :boolean          default(TRUE), not null
-#
+#  heal_group_name           :string           default("Global"), not null
+#  invite_end                :string           default("No link"), not null
 
 class User < ApplicationRecord
   include Settings::Extend

--- a/app/serializers/rest/status_serializer.rb
+++ b/app/serializers/rest/status_serializer.rb
@@ -4,7 +4,7 @@ class REST::StatusSerializer < ActiveModel::Serializer
   attributes :id, :created_at, :in_reply_to_id, :in_reply_to_account_id,
              :sensitive, :spoiler_text, :visibility, :language,
              :uri, :url, :replies_count, :reblogs_count,
-             :favourites_count, :futureself # this allows the attribute to be included when serialized
+             :favourites_count, :futureself, :goal # this allows the attribute to be included when serialized
 
   attribute :favourited, if: :current_user?
   attribute :reblogged, if: :current_user?

--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -53,6 +53,7 @@ class PostStatusService < BaseService
     @scheduled_at = @options[:scheduled_at]&.to_datetime
     @scheduled_at = nil if scheduled_in_the_past?
     @futureself   = @options[:futureself] # this pulls in the value which was passed from the endpoint
+    @goal   = @options[:goal] # this pulls in the value which was passed from the endpoint
   rescue ArgumentError
     raise ActiveRecord::RecordInvalid
   end
@@ -160,6 +161,7 @@ class PostStatusService < BaseService
       spoiler_text: @options[:spoiler_text] || '',
       visibility: @visibility,
       futureself: @futureself, # this is where the attribute is set when sent to db
+      goal: @goal, # this is where the attribute is set when sent to db
       language: language_from_option(@options[:language]) || @account.user&.setting_default_language&.presence || LanguageDetector.instance.detect(@text, @account),
       application: @options[:application],
     }.compact

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -89,6 +89,9 @@ end
 
 ActiveRecordQueryTrace.enabled = ENV['QUERY_TRACE_ENABLED'] == 'true'
 
+# if on macOS this sets path to /convert **required imagemagick (brew install imagemagick)
+# Paperclip.options[:command_path] = "/usr/local/bin/"
+
 module PrivateAddressCheck
   def self.private_address?(*)
     false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,892 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2019_12_12_003415) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "account_aliases", force: :cascade do |t|
+    t.bigint "account_id"
+    t.string "acct", default: "", null: false
+    t.string "uri", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id"], name: "index_account_aliases_on_account_id"
+  end
+
+  create_table "account_conversations", force: :cascade do |t|
+    t.bigint "account_id"
+    t.bigint "conversation_id"
+    t.bigint "participant_account_ids", default: [], null: false, array: true
+    t.bigint "status_ids", default: [], null: false, array: true
+    t.bigint "last_status_id"
+    t.integer "lock_version", default: 0, null: false
+    t.boolean "unread", default: false, null: false
+    t.index ["account_id", "conversation_id", "participant_account_ids"], name: "index_unique_conversations", unique: true
+    t.index ["account_id"], name: "index_account_conversations_on_account_id"
+    t.index ["conversation_id"], name: "index_account_conversations_on_conversation_id"
+  end
+
+  create_table "account_domain_blocks", force: :cascade do |t|
+    t.string "domain"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "account_id"
+    t.index ["account_id", "domain"], name: "index_account_domain_blocks_on_account_id_and_domain", unique: true
+  end
+
+  create_table "account_identity_proofs", force: :cascade do |t|
+    t.bigint "account_id"
+    t.string "provider", default: "", null: false
+    t.string "provider_username", default: "", null: false
+    t.text "token", default: "", null: false
+    t.boolean "verified", default: false, null: false
+    t.boolean "live", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id", "provider", "provider_username"], name: "index_account_proofs_on_account_and_provider_and_username", unique: true
+    t.index ["account_id"], name: "index_account_identity_proofs_on_account_id"
+  end
+
+  create_table "account_migrations", force: :cascade do |t|
+    t.bigint "account_id"
+    t.string "acct", default: "", null: false
+    t.bigint "followers_count", default: 0, null: false
+    t.bigint "target_account_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id"], name: "index_account_migrations_on_account_id"
+    t.index ["target_account_id"], name: "index_account_migrations_on_target_account_id"
+  end
+
+  create_table "account_moderation_notes", force: :cascade do |t|
+    t.text "content", null: false
+    t.bigint "account_id", null: false
+    t.bigint "target_account_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id"], name: "index_account_moderation_notes_on_account_id"
+    t.index ["target_account_id"], name: "index_account_moderation_notes_on_target_account_id"
+  end
+
+  create_table "account_pins", force: :cascade do |t|
+    t.bigint "account_id"
+    t.bigint "target_account_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id", "target_account_id"], name: "index_account_pins_on_account_id_and_target_account_id", unique: true
+    t.index ["account_id"], name: "index_account_pins_on_account_id"
+    t.index ["target_account_id"], name: "index_account_pins_on_target_account_id"
+  end
+
+  create_table "account_stats", force: :cascade do |t|
+    t.bigint "account_id", null: false
+    t.bigint "statuses_count", default: 0, null: false
+    t.bigint "following_count", default: 0, null: false
+    t.bigint "followers_count", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "last_status_at"
+    t.integer "lock_version", default: 0, null: false
+    t.index ["account_id"], name: "index_account_stats_on_account_id", unique: true
+  end
+
+  create_table "account_tag_stats", force: :cascade do |t|
+    t.bigint "tag_id", null: false
+    t.bigint "accounts_count", default: 0, null: false
+    t.boolean "hidden", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["tag_id"], name: "index_account_tag_stats_on_tag_id", unique: true
+  end
+
+  create_table "account_warning_presets", force: :cascade do |t|
+    t.text "text", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "account_warnings", force: :cascade do |t|
+    t.bigint "account_id"
+    t.bigint "target_account_id"
+    t.integer "action", default: 0, null: false
+    t.text "text", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id"], name: "index_account_warnings_on_account_id"
+    t.index ["target_account_id"], name: "index_account_warnings_on_target_account_id"
+  end
+
+  create_table "accounts", force: :cascade do |t|
+    t.string "username", default: "", null: false
+    t.string "domain"
+    t.string "secret", default: "", null: false
+    t.text "private_key"
+    t.text "public_key", default: "", null: false
+    t.string "remote_url", default: "", null: false
+    t.string "salmon_url", default: "", null: false
+    t.string "hub_url", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.text "note", default: "", null: false
+    t.string "display_name", default: "", null: false
+    t.string "uri", default: "", null: false
+    t.string "url"
+    t.string "avatar_file_name"
+    t.string "avatar_content_type"
+    t.integer "avatar_file_size"
+    t.datetime "avatar_updated_at"
+    t.string "header_file_name"
+    t.string "header_content_type"
+    t.integer "header_file_size"
+    t.datetime "header_updated_at"
+    t.string "avatar_remote_url"
+    t.datetime "subscription_expires_at"
+    t.boolean "locked", default: false, null: false
+    t.string "header_remote_url", default: "", null: false
+    t.datetime "last_webfingered_at"
+    t.string "inbox_url", default: "", null: false
+    t.string "outbox_url", default: "", null: false
+    t.string "shared_inbox_url", default: "", null: false
+    t.string "followers_url", default: "", null: false
+    t.integer "protocol", default: 0, null: false
+    t.boolean "memorial", default: false, null: false
+    t.bigint "moved_to_account_id"
+    t.string "featured_collection_url"
+    t.jsonb "fields"
+    t.string "actor_type"
+    t.boolean "discoverable"
+    t.string "also_known_as", array: true
+    t.datetime "silenced_at"
+    t.datetime "suspended_at"
+    t.integer "trust_level"
+    t.index "(((setweight(to_tsvector('simple'::regconfig, (display_name)::text), 'A'::\"char\") || setweight(to_tsvector('simple'::regconfig, (username)::text), 'B'::\"char\")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(domain, ''::character varying))::text), 'C'::\"char\")))", name: "search_index", using: :gin
+    t.index "lower((username)::text), lower((domain)::text)", name: "index_accounts_on_username_and_domain_lower", unique: true
+    t.index ["moved_to_account_id"], name: "index_accounts_on_moved_to_account_id"
+    t.index ["uri"], name: "index_accounts_on_uri"
+    t.index ["url"], name: "index_accounts_on_url"
+  end
+
+  create_table "accounts_tags", id: false, force: :cascade do |t|
+    t.bigint "account_id", null: false
+    t.bigint "tag_id", null: false
+    t.index ["account_id", "tag_id"], name: "index_accounts_tags_on_account_id_and_tag_id"
+    t.index ["tag_id", "account_id"], name: "index_accounts_tags_on_tag_id_and_account_id", unique: true
+  end
+
+  create_table "admin_action_logs", force: :cascade do |t|
+    t.bigint "account_id"
+    t.string "action", default: "", null: false
+    t.string "target_type"
+    t.bigint "target_id"
+    t.text "recorded_changes", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id"], name: "index_admin_action_logs_on_account_id"
+    t.index ["target_type", "target_id"], name: "index_admin_action_logs_on_target_type_and_target_id"
+  end
+
+  create_table "backups", force: :cascade do |t|
+    t.bigint "user_id"
+    t.string "dump_file_name"
+    t.string "dump_content_type"
+    t.bigint "dump_file_size"
+    t.datetime "dump_updated_at"
+    t.boolean "processed", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "blocks", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "account_id", null: false
+    t.bigint "target_account_id", null: false
+    t.string "uri"
+    t.index ["account_id", "target_account_id"], name: "index_blocks_on_account_id_and_target_account_id", unique: true
+    t.index ["target_account_id"], name: "index_blocks_on_target_account_id"
+  end
+
+  create_table "bookmarks", force: :cascade do |t|
+    t.bigint "account_id", null: false
+    t.bigint "status_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id", "status_id"], name: "index_bookmarks_on_account_id_and_status_id", unique: true
+    t.index ["account_id"], name: "index_bookmarks_on_account_id"
+    t.index ["status_id"], name: "index_bookmarks_on_status_id"
+  end
+
+  create_table "conversation_mutes", force: :cascade do |t|
+    t.bigint "conversation_id", null: false
+    t.bigint "account_id", null: false
+    t.index ["account_id", "conversation_id"], name: "index_conversation_mutes_on_account_id_and_conversation_id", unique: true
+  end
+
+  create_table "conversations", force: :cascade do |t|
+    t.string "uri"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["uri"], name: "index_conversations_on_uri", unique: true
+  end
+
+  create_table "custom_emoji_categories", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_custom_emoji_categories_on_name", unique: true
+  end
+
+  create_table "custom_emojis", force: :cascade do |t|
+    t.string "shortcode", default: "", null: false
+    t.string "domain"
+    t.string "image_file_name"
+    t.string "image_content_type"
+    t.integer "image_file_size"
+    t.datetime "image_updated_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "disabled", default: false, null: false
+    t.string "uri"
+    t.string "image_remote_url"
+    t.boolean "visible_in_picker", default: true, null: false
+    t.bigint "category_id"
+    t.index ["shortcode", "domain"], name: "index_custom_emojis_on_shortcode_and_domain", unique: true
+  end
+
+  create_table "custom_filters", force: :cascade do |t|
+    t.bigint "account_id"
+    t.datetime "expires_at"
+    t.text "phrase", default: "", null: false
+    t.string "context", default: [], null: false, array: true
+    t.boolean "irreversible", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "whole_word", default: true, null: false
+    t.index ["account_id"], name: "index_custom_filters_on_account_id"
+  end
+
+  create_table "domain_allows", force: :cascade do |t|
+    t.string "domain", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["domain"], name: "index_domain_allows_on_domain", unique: true
+  end
+
+  create_table "domain_blocks", force: :cascade do |t|
+    t.string "domain", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "severity", default: 0
+    t.boolean "reject_media", default: false, null: false
+    t.boolean "reject_reports", default: false, null: false
+    t.text "private_comment"
+    t.text "public_comment"
+    t.index ["domain"], name: "index_domain_blocks_on_domain", unique: true
+  end
+
+  create_table "email_domain_blocks", force: :cascade do |t|
+    t.string "domain", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["domain"], name: "index_email_domain_blocks_on_domain", unique: true
+  end
+
+  create_table "favourites", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "account_id", null: false
+    t.bigint "status_id", null: false
+    t.index ["account_id", "id"], name: "index_favourites_on_account_id_and_id"
+    t.index ["account_id", "status_id"], name: "index_favourites_on_account_id_and_status_id", unique: true
+    t.index ["status_id"], name: "index_favourites_on_status_id"
+  end
+
+  create_table "featured_tags", force: :cascade do |t|
+    t.bigint "account_id"
+    t.bigint "tag_id"
+    t.bigint "statuses_count", default: 0, null: false
+    t.datetime "last_status_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id"], name: "index_featured_tags_on_account_id"
+    t.index ["tag_id"], name: "index_featured_tags_on_tag_id"
+  end
+
+  create_table "follow_requests", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "account_id", null: false
+    t.bigint "target_account_id", null: false
+    t.boolean "show_reblogs", default: true, null: false
+    t.string "uri"
+    t.index ["account_id", "target_account_id"], name: "index_follow_requests_on_account_id_and_target_account_id", unique: true
+  end
+
+  create_table "follows", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "account_id", null: false
+    t.bigint "target_account_id", null: false
+    t.boolean "show_reblogs", default: true, null: false
+    t.string "uri"
+    t.index ["account_id", "target_account_id"], name: "index_follows_on_account_id_and_target_account_id", unique: true
+    t.index ["target_account_id"], name: "index_follows_on_target_account_id"
+  end
+
+  create_table "identities", force: :cascade do |t|
+    t.string "provider", default: "", null: false
+    t.string "uid", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_identities_on_user_id"
+  end
+
+  create_table "imports", force: :cascade do |t|
+    t.integer "type", null: false
+    t.boolean "approved", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "data_file_name"
+    t.string "data_content_type"
+    t.integer "data_file_size"
+    t.datetime "data_updated_at"
+    t.bigint "account_id", null: false
+    t.boolean "overwrite", default: false, null: false
+  end
+
+  create_table "invites", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "code", default: "", null: false
+    t.datetime "expires_at"
+    t.integer "max_uses"
+    t.integer "uses", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "autofollow", default: false, null: false
+    t.text "comment"
+    t.index ["code"], name: "index_invites_on_code", unique: true
+    t.index ["user_id"], name: "index_invites_on_user_id"
+  end
+
+  create_table "list_accounts", force: :cascade do |t|
+    t.bigint "list_id", null: false
+    t.bigint "account_id", null: false
+    t.bigint "follow_id"
+    t.index ["account_id", "list_id"], name: "index_list_accounts_on_account_id_and_list_id", unique: true
+    t.index ["follow_id"], name: "index_list_accounts_on_follow_id"
+    t.index ["list_id", "account_id"], name: "index_list_accounts_on_list_id_and_account_id"
+  end
+
+  create_table "lists", force: :cascade do |t|
+    t.bigint "account_id", null: false
+    t.string "title", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id"], name: "index_lists_on_account_id"
+  end
+
+  create_table "markers", force: :cascade do |t|
+    t.bigint "user_id"
+    t.string "timeline", default: "", null: false
+    t.bigint "last_read_id", default: 0, null: false
+    t.integer "lock_version", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "timeline"], name: "index_markers_on_user_id_and_timeline", unique: true
+    t.index ["user_id"], name: "index_markers_on_user_id"
+  end
+
+  create_table "media_attachments", force: :cascade do |t|
+    t.bigint "status_id"
+    t.string "file_file_name"
+    t.string "file_content_type"
+    t.integer "file_file_size"
+    t.datetime "file_updated_at"
+    t.string "remote_url", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "shortcode"
+    t.integer "type", default: 0, null: false
+    t.json "file_meta"
+    t.bigint "account_id"
+    t.text "description"
+    t.bigint "scheduled_status_id"
+    t.string "blurhash"
+    t.index ["account_id"], name: "index_media_attachments_on_account_id"
+    t.index ["scheduled_status_id"], name: "index_media_attachments_on_scheduled_status_id"
+    t.index ["shortcode"], name: "index_media_attachments_on_shortcode", unique: true
+    t.index ["status_id"], name: "index_media_attachments_on_status_id"
+  end
+
+  create_table "mentions", force: :cascade do |t|
+    t.bigint "status_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "account_id"
+    t.boolean "silent", default: false, null: false
+    t.index ["account_id", "status_id"], name: "index_mentions_on_account_id_and_status_id", unique: true
+    t.index ["status_id"], name: "index_mentions_on_status_id"
+  end
+
+  create_table "mutes", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "hide_notifications", default: true, null: false
+    t.bigint "account_id", null: false
+    t.bigint "target_account_id", null: false
+    t.index ["account_id", "target_account_id"], name: "index_mutes_on_account_id_and_target_account_id", unique: true
+    t.index ["target_account_id"], name: "index_mutes_on_target_account_id"
+  end
+
+  create_table "notifications", force: :cascade do |t|
+    t.bigint "activity_id", null: false
+    t.string "activity_type", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "account_id", null: false
+    t.bigint "from_account_id", null: false
+    t.index ["account_id", "activity_id", "activity_type"], name: "account_activity", unique: true
+    t.index ["account_id", "id"], name: "index_notifications_on_account_id_and_id", order: { id: :desc }
+    t.index ["activity_id", "activity_type"], name: "index_notifications_on_activity_id_and_activity_type"
+    t.index ["from_account_id"], name: "index_notifications_on_from_account_id"
+  end
+
+  create_table "oauth_access_grants", force: :cascade do |t|
+    t.string "token", null: false
+    t.integer "expires_in", null: false
+    t.text "redirect_uri", null: false
+    t.datetime "created_at", null: false
+    t.datetime "revoked_at"
+    t.string "scopes"
+    t.bigint "application_id", null: false
+    t.bigint "resource_owner_id", null: false
+    t.index ["resource_owner_id"], name: "index_oauth_access_grants_on_resource_owner_id"
+    t.index ["token"], name: "index_oauth_access_grants_on_token", unique: true
+  end
+
+  create_table "oauth_access_tokens", force: :cascade do |t|
+    t.string "token", null: false
+    t.string "refresh_token"
+    t.integer "expires_in"
+    t.datetime "revoked_at"
+    t.datetime "created_at", null: false
+    t.string "scopes"
+    t.bigint "application_id"
+    t.bigint "resource_owner_id"
+    t.index ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true
+    t.index ["resource_owner_id"], name: "index_oauth_access_tokens_on_resource_owner_id"
+    t.index ["token"], name: "index_oauth_access_tokens_on_token", unique: true
+  end
+
+  create_table "oauth_applications", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "uid", null: false
+    t.string "secret", null: false
+    t.text "redirect_uri", null: false
+    t.string "scopes", default: "", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.boolean "superapp", default: false, null: false
+    t.string "website"
+    t.string "owner_type"
+    t.bigint "owner_id"
+    t.boolean "confidential", default: true, null: false
+    t.index ["owner_id", "owner_type"], name: "index_oauth_applications_on_owner_id_and_owner_type"
+    t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
+  end
+
+  create_table "pghero_space_stats", force: :cascade do |t|
+    t.text "database"
+    t.text "schema"
+    t.text "relation"
+    t.bigint "size"
+    t.datetime "captured_at"
+    t.index ["database", "captured_at"], name: "index_pghero_space_stats_on_database_and_captured_at"
+  end
+
+  create_table "poll_votes", force: :cascade do |t|
+    t.bigint "account_id"
+    t.bigint "poll_id"
+    t.integer "choice", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "uri"
+    t.index ["account_id"], name: "index_poll_votes_on_account_id"
+    t.index ["poll_id"], name: "index_poll_votes_on_poll_id"
+  end
+
+  create_table "polls", force: :cascade do |t|
+    t.bigint "account_id"
+    t.bigint "status_id"
+    t.datetime "expires_at"
+    t.string "options", default: [], null: false, array: true
+    t.bigint "cached_tallies", default: [], null: false, array: true
+    t.boolean "multiple", default: false, null: false
+    t.boolean "hide_totals", default: false, null: false
+    t.bigint "votes_count", default: 0, null: false
+    t.datetime "last_fetched_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "lock_version", default: 0, null: false
+    t.bigint "voters_count"
+    t.index ["account_id"], name: "index_polls_on_account_id"
+    t.index ["status_id"], name: "index_polls_on_status_id"
+  end
+
+  create_table "preview_cards", force: :cascade do |t|
+    t.string "url", default: "", null: false
+    t.string "title", default: "", null: false
+    t.string "description", default: "", null: false
+    t.string "image_file_name"
+    t.string "image_content_type"
+    t.integer "image_file_size"
+    t.datetime "image_updated_at"
+    t.integer "type", default: 0, null: false
+    t.text "html", default: "", null: false
+    t.string "author_name", default: "", null: false
+    t.string "author_url", default: "", null: false
+    t.string "provider_name", default: "", null: false
+    t.string "provider_url", default: "", null: false
+    t.integer "width", default: 0, null: false
+    t.integer "height", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "embed_url", default: "", null: false
+    t.index ["url"], name: "index_preview_cards_on_url", unique: true
+  end
+
+  create_table "preview_cards_statuses", id: false, force: :cascade do |t|
+    t.bigint "preview_card_id", null: false
+    t.bigint "status_id", null: false
+    t.index ["status_id", "preview_card_id"], name: "index_preview_cards_statuses_on_status_id_and_preview_card_id"
+  end
+
+  create_table "relays", force: :cascade do |t|
+    t.string "inbox_url", default: "", null: false
+    t.string "follow_activity_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "state", default: 0, null: false
+  end
+
+  create_table "report_notes", force: :cascade do |t|
+    t.text "content", null: false
+    t.bigint "report_id", null: false
+    t.bigint "account_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id"], name: "index_report_notes_on_account_id"
+    t.index ["report_id"], name: "index_report_notes_on_report_id"
+  end
+
+  create_table "reports", force: :cascade do |t|
+    t.bigint "status_ids", default: [], null: false, array: true
+    t.text "comment", default: "", null: false
+    t.boolean "action_taken", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "account_id", null: false
+    t.bigint "action_taken_by_account_id"
+    t.bigint "target_account_id", null: false
+    t.bigint "assigned_account_id"
+    t.string "uri"
+    t.index ["account_id"], name: "index_reports_on_account_id"
+    t.index ["target_account_id"], name: "index_reports_on_target_account_id"
+  end
+
+  create_table "scheduled_statuses", force: :cascade do |t|
+    t.bigint "account_id"
+    t.datetime "scheduled_at"
+    t.jsonb "params"
+    t.index ["account_id"], name: "index_scheduled_statuses_on_account_id"
+    t.index ["scheduled_at"], name: "index_scheduled_statuses_on_scheduled_at"
+  end
+
+  create_table "session_activations", force: :cascade do |t|
+    t.string "session_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "user_agent", default: "", null: false
+    t.inet "ip"
+    t.bigint "access_token_id"
+    t.bigint "user_id", null: false
+    t.bigint "web_push_subscription_id"
+    t.index ["access_token_id"], name: "index_session_activations_on_access_token_id"
+    t.index ["session_id"], name: "index_session_activations_on_session_id", unique: true
+    t.index ["user_id"], name: "index_session_activations_on_user_id"
+  end
+
+  create_table "settings", force: :cascade do |t|
+    t.string "var", null: false
+    t.text "value"
+    t.string "thing_type"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.bigint "thing_id"
+    t.index ["thing_type", "thing_id", "var"], name: "index_settings_on_thing_type_and_thing_id_and_var", unique: true
+  end
+
+  create_table "site_uploads", force: :cascade do |t|
+    t.string "var", default: "", null: false
+    t.string "file_file_name"
+    t.string "file_content_type"
+    t.integer "file_file_size"
+    t.datetime "file_updated_at"
+    t.json "meta"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["var"], name: "index_site_uploads_on_var", unique: true
+  end
+
+  create_table "status_pins", force: :cascade do |t|
+    t.bigint "account_id", null: false
+    t.bigint "status_id", null: false
+    t.datetime "created_at", default: -> { "now()" }, null: false
+    t.datetime "updated_at", default: -> { "now()" }, null: false
+    t.index ["account_id", "status_id"], name: "index_status_pins_on_account_id_and_status_id", unique: true
+  end
+
+  create_table "status_stats", force: :cascade do |t|
+    t.bigint "status_id", null: false
+    t.bigint "replies_count", default: 0, null: false
+    t.bigint "reblogs_count", default: 0, null: false
+    t.bigint "favourites_count", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["status_id"], name: "index_status_stats_on_status_id", unique: true
+  end
+
+  create_table "statuses", id: :bigint, default: -> { "timestamp_id('statuses'::text)" }, force: :cascade do |t|
+    t.string "uri"
+    t.text "text", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "in_reply_to_id"
+    t.bigint "reblog_of_id"
+    t.string "url"
+    t.boolean "sensitive", default: false, null: false
+    t.integer "visibility", default: 0, null: false
+    t.text "spoiler_text", default: "", null: false
+    t.boolean "reply", default: false, null: false
+    t.string "language"
+    t.bigint "conversation_id"
+    t.boolean "local"
+    t.bigint "account_id", null: false
+    t.bigint "application_id"
+    t.bigint "in_reply_to_account_id"
+    t.bigint "poll_id"
+    t.datetime "deleted_at"
+    t.boolean "futureself"
+    t.boolean "goal"
+    t.index ["account_id", "id", "visibility", "updated_at"], name: "index_statuses_20190820", order: { id: :desc }, where: "(deleted_at IS NULL)"
+    t.index ["id", "account_id"], name: "index_statuses_local_20190824", order: { id: :desc }, where: "((local OR (uri IS NULL)) AND (deleted_at IS NULL) AND (visibility = 0) AND (reblog_of_id IS NULL) AND ((NOT reply) OR (in_reply_to_account_id = account_id)))"
+    t.index ["in_reply_to_account_id"], name: "index_statuses_on_in_reply_to_account_id"
+    t.index ["in_reply_to_id"], name: "index_statuses_on_in_reply_to_id"
+    t.index ["reblog_of_id", "account_id"], name: "index_statuses_on_reblog_of_id_and_account_id"
+    t.index ["uri"], name: "index_statuses_on_uri", unique: true
+  end
+
+  create_table "statuses_tags", id: false, force: :cascade do |t|
+    t.bigint "status_id", null: false
+    t.bigint "tag_id", null: false
+    t.index ["status_id"], name: "index_statuses_tags_on_status_id"
+    t.index ["tag_id", "status_id"], name: "index_statuses_tags_on_tag_id_and_status_id", unique: true
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "usable"
+    t.boolean "trendable"
+    t.boolean "listable"
+    t.datetime "reviewed_at"
+    t.datetime "requested_review_at"
+    t.datetime "last_status_at"
+    t.float "max_score"
+    t.datetime "max_score_at"
+    t.index "lower((name)::text)", name: "index_tags_on_name_lower", unique: true
+  end
+
+  create_table "tombstones", force: :cascade do |t|
+    t.bigint "account_id"
+    t.string "uri", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "by_moderator"
+    t.index ["account_id"], name: "index_tombstones_on_account_id"
+    t.index ["uri"], name: "index_tombstones_on_uri"
+  end
+
+  create_table "user_invite_requests", force: :cascade do |t|
+    t.bigint "user_id"
+    t.text "text"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_user_invite_requests_on_user_id"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.integer "sign_in_count", default: 0, null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.inet "current_sign_in_ip"
+    t.inet "last_sign_in_ip"
+    t.boolean "admin", default: false, null: false
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
+    t.string "locale"
+    t.string "encrypted_otp_secret"
+    t.string "encrypted_otp_secret_iv"
+    t.string "encrypted_otp_secret_salt"
+    t.integer "consumed_timestep"
+    t.boolean "otp_required_for_login", default: false, null: false
+    t.datetime "last_emailed_at"
+    t.string "otp_backup_codes", array: true
+    t.string "filtered_languages", default: [], null: false, array: true
+    t.bigint "account_id", null: false
+    t.boolean "disabled", default: false, null: false
+    t.boolean "moderator", default: false, null: false
+    t.bigint "invite_id"
+    t.string "remember_token"
+    t.string "chosen_languages", array: true
+    t.bigint "created_by_application_id"
+    t.boolean "approved", default: true, null: false
+    t.string "heal_group_name", default: "Global", null: false
+    t.string "invite_end", default: "No link", null: false
+    t.index ["account_id"], name: "index_users_on_account_id"
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
+    t.index ["created_by_application_id"], name: "index_users_on_created_by_application_id"
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["remember_token"], name: "index_users_on_remember_token", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  end
+
+  create_table "web_push_subscriptions", force: :cascade do |t|
+    t.string "endpoint", null: false
+    t.string "key_p256dh", null: false
+    t.string "key_auth", null: false
+    t.json "data"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "access_token_id"
+    t.bigint "user_id"
+    t.index ["access_token_id"], name: "index_web_push_subscriptions_on_access_token_id"
+    t.index ["user_id"], name: "index_web_push_subscriptions_on_user_id"
+  end
+
+  create_table "web_settings", force: :cascade do |t|
+    t.json "data"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_web_settings_on_user_id", unique: true
+  end
+
+  add_foreign_key "account_aliases", "accounts", on_delete: :cascade
+  add_foreign_key "account_conversations", "accounts", on_delete: :cascade
+  add_foreign_key "account_conversations", "conversations", on_delete: :cascade
+  add_foreign_key "account_domain_blocks", "accounts", name: "fk_206c6029bd", on_delete: :cascade
+  add_foreign_key "account_identity_proofs", "accounts", on_delete: :cascade
+  add_foreign_key "account_migrations", "accounts", column: "target_account_id", on_delete: :nullify
+  add_foreign_key "account_migrations", "accounts", on_delete: :cascade
+  add_foreign_key "account_moderation_notes", "accounts"
+  add_foreign_key "account_moderation_notes", "accounts", column: "target_account_id"
+  add_foreign_key "account_pins", "accounts", column: "target_account_id", on_delete: :cascade
+  add_foreign_key "account_pins", "accounts", on_delete: :cascade
+  add_foreign_key "account_stats", "accounts", on_delete: :cascade
+  add_foreign_key "account_tag_stats", "tags", on_delete: :cascade
+  add_foreign_key "account_warnings", "accounts", column: "target_account_id", on_delete: :cascade
+  add_foreign_key "account_warnings", "accounts", on_delete: :nullify
+  add_foreign_key "accounts", "accounts", column: "moved_to_account_id", on_delete: :nullify
+  add_foreign_key "admin_action_logs", "accounts", on_delete: :cascade
+  add_foreign_key "backups", "users", on_delete: :nullify
+  add_foreign_key "blocks", "accounts", column: "target_account_id", name: "fk_9571bfabc1", on_delete: :cascade
+  add_foreign_key "blocks", "accounts", name: "fk_4269e03e65", on_delete: :cascade
+  add_foreign_key "bookmarks", "accounts", on_delete: :cascade
+  add_foreign_key "bookmarks", "statuses", on_delete: :cascade
+  add_foreign_key "conversation_mutes", "accounts", name: "fk_225b4212bb", on_delete: :cascade
+  add_foreign_key "conversation_mutes", "conversations", on_delete: :cascade
+  add_foreign_key "custom_filters", "accounts", on_delete: :cascade
+  add_foreign_key "favourites", "accounts", name: "fk_5eb6c2b873", on_delete: :cascade
+  add_foreign_key "favourites", "statuses", name: "fk_b0e856845e", on_delete: :cascade
+  add_foreign_key "featured_tags", "accounts", on_delete: :cascade
+  add_foreign_key "featured_tags", "tags", on_delete: :cascade
+  add_foreign_key "follow_requests", "accounts", column: "target_account_id", name: "fk_9291ec025d", on_delete: :cascade
+  add_foreign_key "follow_requests", "accounts", name: "fk_76d644b0e7", on_delete: :cascade
+  add_foreign_key "follows", "accounts", column: "target_account_id", name: "fk_745ca29eac", on_delete: :cascade
+  add_foreign_key "follows", "accounts", name: "fk_32ed1b5560", on_delete: :cascade
+  add_foreign_key "identities", "users", name: "fk_bea040f377", on_delete: :cascade
+  add_foreign_key "imports", "accounts", name: "fk_6db1b6e408", on_delete: :cascade
+  add_foreign_key "invites", "users", on_delete: :cascade
+  add_foreign_key "list_accounts", "accounts", on_delete: :cascade
+  add_foreign_key "list_accounts", "follows", on_delete: :cascade
+  add_foreign_key "list_accounts", "lists", on_delete: :cascade
+  add_foreign_key "lists", "accounts", on_delete: :cascade
+  add_foreign_key "markers", "users", on_delete: :cascade
+  add_foreign_key "media_attachments", "accounts", name: "fk_96dd81e81b", on_delete: :nullify
+  add_foreign_key "media_attachments", "scheduled_statuses", on_delete: :nullify
+  add_foreign_key "media_attachments", "statuses", on_delete: :nullify
+  add_foreign_key "mentions", "accounts", name: "fk_970d43f9d1", on_delete: :cascade
+  add_foreign_key "mentions", "statuses", on_delete: :cascade
+  add_foreign_key "mutes", "accounts", column: "target_account_id", name: "fk_eecff219ea", on_delete: :cascade
+  add_foreign_key "mutes", "accounts", name: "fk_b8d8daf315", on_delete: :cascade
+  add_foreign_key "notifications", "accounts", column: "from_account_id", name: "fk_fbd6b0bf9e", on_delete: :cascade
+  add_foreign_key "notifications", "accounts", name: "fk_c141c8ee55", on_delete: :cascade
+  add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id", name: "fk_34d54b0a33", on_delete: :cascade
+  add_foreign_key "oauth_access_grants", "users", column: "resource_owner_id", name: "fk_63b044929b", on_delete: :cascade
+  add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id", name: "fk_f5fc4c1ee3", on_delete: :cascade
+  add_foreign_key "oauth_access_tokens", "users", column: "resource_owner_id", name: "fk_e84df68546", on_delete: :cascade
+  add_foreign_key "oauth_applications", "users", column: "owner_id", name: "fk_b0988c7c0a", on_delete: :cascade
+  add_foreign_key "poll_votes", "accounts", on_delete: :cascade
+  add_foreign_key "poll_votes", "polls", on_delete: :cascade
+  add_foreign_key "polls", "accounts", on_delete: :cascade
+  add_foreign_key "polls", "statuses", on_delete: :cascade
+  add_foreign_key "report_notes", "accounts", on_delete: :cascade
+  add_foreign_key "report_notes", "reports", on_delete: :cascade
+  add_foreign_key "reports", "accounts", column: "action_taken_by_account_id", name: "fk_bca45b75fd", on_delete: :nullify
+  add_foreign_key "reports", "accounts", column: "assigned_account_id", on_delete: :nullify
+  add_foreign_key "reports", "accounts", column: "target_account_id", name: "fk_eb37af34f0", on_delete: :cascade
+  add_foreign_key "reports", "accounts", name: "fk_4b81f7522c", on_delete: :cascade
+  add_foreign_key "scheduled_statuses", "accounts", on_delete: :cascade
+  add_foreign_key "session_activations", "oauth_access_tokens", column: "access_token_id", name: "fk_957e5bda89", on_delete: :cascade
+  add_foreign_key "session_activations", "users", name: "fk_e5fda67334", on_delete: :cascade
+  add_foreign_key "status_pins", "accounts", name: "fk_d4cb435b62", on_delete: :cascade
+  add_foreign_key "status_pins", "statuses", on_delete: :cascade
+  add_foreign_key "status_stats", "statuses", on_delete: :cascade
+  add_foreign_key "statuses", "accounts", column: "in_reply_to_account_id", name: "fk_c7fa917661", on_delete: :nullify
+  add_foreign_key "statuses", "accounts", name: "fk_9bda1543f7", on_delete: :cascade
+  add_foreign_key "statuses", "statuses", column: "in_reply_to_id", on_delete: :nullify
+  add_foreign_key "statuses", "statuses", column: "reblog_of_id", on_delete: :cascade
+  add_foreign_key "statuses_tags", "statuses", on_delete: :cascade
+  add_foreign_key "statuses_tags", "tags", name: "fk_3081861e21", on_delete: :cascade
+  add_foreign_key "tombstones", "accounts", on_delete: :cascade
+  add_foreign_key "user_invite_requests", "users", on_delete: :cascade
+  add_foreign_key "users", "accounts", name: "fk_50500f500d", on_delete: :cascade
+  add_foreign_key "users", "invites", on_delete: :nullify
+  add_foreign_key "users", "oauth_applications", column: "created_by_application_id", on_delete: :nullify
+  add_foreign_key "web_push_subscriptions", "oauth_access_tokens", column: "access_token_id", on_delete: :cascade
+  add_foreign_key "web_push_subscriptions", "users", on_delete: :cascade
+  add_foreign_key "web_settings", "users", name: "fk_11910667b2", on_delete: :cascade
+end


### PR DESCRIPTION
#### TO TEST
`git checkout TG-15-goals && git pull`

#### REQUIRED
##### PSQL Changes
psql users table must have 'futureself:boolean' and 'goal:boolean'
```sql
alter table statuses add column goal boolean;
alter table statuses add column futureself boolean;
```

Could also attempt to use (warning: I am not certain if this updates the db or drops schema and replaces):
`RAILS_ENV=development bundle exec rails db:schema:load`

##### Mastodon
- two user accounts (for ease of testing use two separate browsers), affectionately referred to as User A (UA) and User B (UB).
- UA has made a futureself post
- a few non-futureself posts made by both users

#### Acceptance Tests
- [x] AC1: As UA there is a flag icon in the status_bar (the footer of a status) **ONLY** on futureself posts **MADE BY** UA. (Same should be true for UB)
- [x] AC2: GoalForm Post
  - [x] AC2.1: As UA, clicking on the flag icon transforms the compose_form into a goal form.
  - [x] AC2.2: The post is unlisted (as denoted by the unlocked lock icon in the compose form footer.
  - [x] AC2.3: FutureSelf icon in the composeform footer is disabled.
  - [x] AC2.4: there is a reply component above the form that references the futureself post.
  - [x] AC2.5: clicking the 'x' on the reply component cancels the goal post and returns to a normal compose_form component.
  - [x] [*](#*)AC2.6: composing a post after cancelling submits a 'normal' post { ... futureSelf=>false, goal=>false}
__--return to goalform post by again clicking on the flag--__
  - [x] AC2.7: Prior to filling out the form clicking on 'Post' Submit button does nothing.
  - [x] AC2.8: Without all user input in each of the three fields 'Post' does nothing.
  - [x] [*](#*)AC2.9: composing a goal post submits a goal post with the { ... visibility=>unlisted, ... goal=>true}
- [x] AC3: GoalForm Status 
  - [x] AC3.1: In main My Group Timeline goal is posted as a reply to the futureself post and is formatted in a pretty unique to goal way. 
  - [x] AC3.2: In Future Self timeline goal shows up.
  - [x] AC3.3: When pressing the '...' in the status_bar and selected delete and re-draft the goal form is brought back up and still correctly references the futureself post. _Note: The form will be empty again to take in new and inspiring ideas_.
- [x] AC4: Nothing is broken or weird when you try to break things xD

#### To Close
If all tests pass, approve and merge with commit message `TG-15 #closed, TG-82 #closed, TG-83 #closed, TG-91 #closed, TG-92 #closed, TG-93 #closed`


#### *
can confirm the type of post by checking the database or looking at the foreman logs:
##### ex of expected results for a goal post:
```
22:17:14 web.1     |  Started POST "/api/v1/statuses" for 127.0.0.1 at 2020-03-11 22:17:14 -0700
22:17:14 web.1     | Processing by Api::V1::StatusesController#create as HTML
22:17:14 web.1     |   Parameters: {"status"=>"To be the next Jacob Wallert.,He does the things.,Do the things.", "in_reply_to_id"=>"103800528283969261", "media_ids"=>[], "sensitive"=>false, "spoiler_text"=>"", "visibility"=>"unlisted", "poll"=>nil, "futureSelf"=>false, "goal"=>true}
```
##### ex of expected results for a normal post:
```
22:18:14 web.1     | Started POST "/api/v1/statuses" for 127.0.0.1 at 2020-03-11 22:18:14 -0700
22:18:15 web.1     | Processing by Api::V1::StatusesController#create as HTML
22:18:15 web.1     |   Parameters: {"status"=>"hi mom 😍 ", "in_reply_to_id"=>nil, "media_ids"=>[], "sensitive"=>false, "spoiler_text"=>"", "visibility"=>"public", "poll"=>nil, "futureSelf"=>false, "goal"=>false}
```